### PR TITLE
Add pie charts for PRs by repos and PRs by contributors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import { PRsByRepository } from "./components/PRsByRepository"
 import { Modal } from "./components/Modal"
 import { useContributorsData } from "./hooks/useContributorsData"
 import ContributorGraph from "./components/ContributorGraph"
+import PRsByRepositoryPieChart from "./components/PRsByRepositoryPieChart"
+import PRsByContributorPieChart from "./components/PRsByContributorPieChart"
 
 function App() {
   const {
@@ -44,6 +46,8 @@ function App() {
         />
 
         <PRsByRepository repositories={repoDetails} />
+        <PRsByRepositoryPieChart repositories={repoDetails} />
+        <PRsByContributorPieChart contributors={sortedContributors} />
 
         <Modal
           isOpen={isModalOpen}

--- a/frontend/src/components/PRsByContributorPieChart.tsx
+++ b/frontend/src/components/PRsByContributorPieChart.tsx
@@ -1,0 +1,40 @@
+import { Pie } from "react-chartjs-2"
+import { useContributorsData } from "../hooks/useContributorsData"
+
+const PRsByContributorPieChart = () => {
+  const { sortedContributors } = useContributorsData()
+
+  const data = {
+    labels: sortedContributors.map(([username]) => username),
+    datasets: [
+      {
+        data: sortedContributors.map(([, stats]) => stats.prsMerged),
+        backgroundColor: [
+          "#FF6384",
+          "#36A2EB",
+          "#FFCE56",
+          "#4BC0C0",
+          "#9966FF",
+          "#FF9F40",
+        ],
+        hoverBackgroundColor: [
+          "#FF6384",
+          "#36A2EB",
+          "#FFCE56",
+          "#4BC0C0",
+          "#9966FF",
+          "#FF9F40",
+        ],
+      },
+    ],
+  }
+
+  return (
+    <div>
+      <h2>PRs by Contributor</h2>
+      <Pie data={data} />
+    </div>
+  )
+}
+
+export default PRsByContributorPieChart

--- a/frontend/src/components/PRsByRepositoryPieChart.tsx
+++ b/frontend/src/components/PRsByRepositoryPieChart.tsx
@@ -1,0 +1,40 @@
+import { Pie } from "react-chartjs-2"
+import { useContributorsData } from "../hooks/useContributorsData"
+
+const PRsByRepositoryPieChart = () => {
+  const { repoDetails } = useContributorsData()
+
+  const data = {
+    labels: repoDetails.map((repo) => repo.name),
+    datasets: [
+      {
+        data: repoDetails.map((repo) => repo.prs.length),
+        backgroundColor: [
+          "#FF6384",
+          "#36A2EB",
+          "#FFCE56",
+          "#4BC0C0",
+          "#9966FF",
+          "#FF9F40",
+        ],
+        hoverBackgroundColor: [
+          "#FF6384",
+          "#36A2EB",
+          "#FFCE56",
+          "#4BC0C0",
+          "#9966FF",
+          "#FF9F40",
+        ],
+      },
+    ],
+  }
+
+  return (
+    <div>
+      <h2>PRs by Repository</h2>
+      <Pie data={data} />
+    </div>
+  )
+}
+
+export default PRsByRepositoryPieChart


### PR DESCRIPTION
Fixes #73

Add pie charts for PRs by repository and PRs by contributor.

* **frontend/src/App.tsx**
  - Import `PRsByRepositoryPieChart` and `PRsByContributorPieChart` components.
  - Add `PRsByRepositoryPieChart` component to render pie chart for PRs by repository.
  - Add `PRsByContributorPieChart` component to render pie chart for PRs by contributor.

* **frontend/src/components/PRsByRepositoryPieChart.tsx**
  - Import `Pie` from `react-chartjs-2`.
  - Define `PRsByRepositoryPieChart` component to render pie chart for PRs by repository.
  - Use `repoDetails` from `useContributorsData` to get data for pie chart.

* **frontend/src/components/PRsByContributorPieChart.tsx**
  - Import `Pie` from `react-chartjs-2`.
  - Define `PRsByContributorPieChart` component to render pie chart for PRs by contributor.
  - Use `sortedContributors` from `useContributorsData` to get data for pie chart.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tscircuit/contribution-tracker/pull/90?shareId=f8b050b5-251e-4220-a7f8-fd29740e4268).