### PR TITLE
fix: distinctPRsReviewed does not adding to overall score

### DIFF
--- a/tests/test-pr-scoring.test.ts
+++ b/tests/test-pr-scoring.test.ts
@@ -1,81 +1,166 @@
-import { expect, test } from "bun:test"
-import { generateMarkdown } from "../lib/data-processing/generateMarkdown"
-import type { ContributorStats, AnalyzedPR } from "../lib/types"
+import { describe, expect, it } from "bun:test"
+import { getContributorScore } from "lib/scoring/getContributorScore"
+import type { AnalyzedPR, ContributorStats } from "lib/types"
 
-const mockPRs: AnalyzedPR[] = [
-  {
-    number: 1,
-    title: "Test PR 1",
-    description: "Test Description 1",
-    impact: "Major",
-    contributor: "user1",
-    repo: "test/repo",
-    url: "https://github.com/test/repo/pull/1",
-  },
-]
-
-test("should count distinct PRs for scoring instead of raw review counts", async () => {
-  const contributorStats: Record<string, ContributorStats> = {
-    user1: {
-      reviewsReceived: 0,
-      rejectionsReceived: 0,
-      approvalsReceived: 0,
-      prsOpened: 1,
-      prsMerged: 0,
-      issuesCreated: 0,
-      approvalsGiven: 1, // One approvals on the same PR
-      rejectionsGiven: 2, // Two rejection on the same PR
-      distinctPrsReviewed: 1, // Should only count as one PR
-      score: 0,
-    },
+it("should count distinct PRs reviewed", () => {
+  const mockPRs: AnalyzedPR[] = []
+  const stats: ContributorStats = {
+    reviewsReceived: 0,
+    rejectionsReceived: 0,
+    approvalsReceived: 0,
+    approvalsGiven: 0,
+    rejectionsGiven: 0,
+    prsOpened: 0,
+    prsMerged: 0,
+    issuesCreated: 0,
+    bountiedIssuesCount: 0,
+    bountiedIssuesTotal: 0,
+    distinctPrsReviewed: 2, // Two distinct PRs reviewed
   }
 
-  await generateMarkdown(mockPRs, contributorStats, "2024-03-01")
-
-  // The score should reflect one PR (capped at 20), not 3 reviews
-  // Plus 4 points for the Major PR contribution
-  expect(contributorStats["user1"].score).toBe(5)
+  const result = getContributorScore(mockPRs, stats)
+  expect(result.score).toBe(2) // Should get 2 points for reviewing 2 distinct PRs
 })
 
-test("should cap review points at 20 even with many distinct PRs", async () => {
-  const contributorStats: Record<string, ContributorStats> = {
-    user1: {
+it("should cap review points at 10", () => {
+  const mockPRs: AnalyzedPR[] = []
+  const stats: ContributorStats = {
+    reviewsReceived: 0,
+    rejectionsReceived: 0,
+    approvalsReceived: 0,
+    approvalsGiven: 0,
+    rejectionsGiven: 0,
+    prsOpened: 0,
+    prsMerged: 0,
+    issuesCreated: 0,
+    bountiedIssuesCount: 0,
+    bountiedIssuesTotal: 0,
+    distinctPrsReviewed: 15, // More than 10 distinct PRs
+  }
+
+  const result = getContributorScore(mockPRs, stats)
+  expect(result.score).toBe(10) // Should be capped at 10 points
+})
+
+it("should handle edge cases", () => {
+  const mockPRs: AnalyzedPR[] = []
+  const stats: ContributorStats = {
+    reviewsReceived: 0,
+    rejectionsReceived: 0,
+    approvalsReceived: 0,
+    approvalsGiven: 0,
+    rejectionsGiven: 0,
+    prsOpened: 0,
+    prsMerged: 0,
+    issuesCreated: 0,
+    bountiedIssuesCount: 0,
+    bountiedIssuesTotal: 0,
+    distinctPrsReviewed: 0, // No PRs reviewed
+  }
+
+  const result = getContributorScore(mockPRs, stats)
+  expect(result.score).toBe(0) // Should return 0 for no reviews
+})
+
+it("should correctly calculate score from distinct PRs reviewed", () => {
+  const mockPRs: AnalyzedPR[] = []
+  const stats: ContributorStats = {
+    reviewsReceived: 0,
+    rejectionsReceived: 0,
+    approvalsReceived: 0,
+    approvalsGiven: 0,
+    rejectionsGiven: 0,
+    prsOpened: 0,
+    prsMerged: 0,
+    issuesCreated: 0,
+    bountiedIssuesCount: 0,
+    bountiedIssuesTotal: 0,
+    distinctPrsReviewed: 5, // Five distinct PRs reviewed
+  }
+
+  const result = getContributorScore(mockPRs, stats)
+  expect(result.score).toBe(5) // Should get 5 points for reviewing 5 distinct PRs
+})
+
+// Additional tests to verify the distinct PRs reviewed functionality
+describe("distinct PRs reviewed functionality", () => {
+  it("should count distinct PRs instead of raw review counts", () => {
+    const mockPRs: AnalyzedPR[] = []
+    const contributorStats: ContributorStats = {
       reviewsReceived: 0,
       rejectionsReceived: 0,
       approvalsReceived: 0,
-      prsOpened: 1,
+      approvalsGiven: 3, // 3 approvals on the same PR
+      rejectionsGiven: 2, // 2 rejections on the same PR
+      prsOpened: 0,
       prsMerged: 0,
       issuesCreated: 0,
+      bountiedIssuesCount: 0,
+      bountiedIssuesTotal: 0,
+      distinctPrsReviewed: 1, // Should only count as one PR
+    }
+
+    const result = getContributorScore(mockPRs, contributorStats)
+    expect(result.score).toBe(1) // Should get 1 point for one distinct PR reviewed
+  })
+
+  it("should cap review points at 10 even with many distinct PRs", () => {
+    const mockPRs: AnalyzedPR[] = []
+    const contributorStats: ContributorStats = {
+      reviewsReceived: 0,
+      rejectionsReceived: 0,
+      approvalsReceived: 0,
       approvalsGiven: 25,
       rejectionsGiven: 5,
+      prsOpened: 0,
+      prsMerged: 0,
+      issuesCreated: 0,
+      bountiedIssuesCount: 0,
+      bountiedIssuesTotal: 0,
       distinctPrsReviewed: 30, // More than the cap
-      score: 0,
-    },
-  }
+    }
 
-  await generateMarkdown(mockPRs, contributorStats, "2024-03-01")
+    const result = getContributorScore(mockPRs, contributorStats)
+    expect(result.score).toBe(10) // Should be capped at 10 points
+  })
 
-  // Score should be 10 (capped) + 4 (Major PR)
-  expect(contributorStats["user1"].score).toBe(14)
-})
-
-test("should handle edge case of no reviews", async () => {
-  const contributorStats: Record<string, ContributorStats> = {
-    user1: {
+  it("should handle edge case of no reviews", () => {
+    const mockPRs: AnalyzedPR[] = []
+    const contributorStats: ContributorStats = {
       reviewsReceived: 0,
       rejectionsReceived: 0,
       approvalsReceived: 0,
-      prsOpened: 1,
-      prsMerged: 0,
-      issuesCreated: 0,
       approvalsGiven: 0,
       rejectionsGiven: 0,
-      score: 0,
-    },
-  }
+      prsOpened: 0,
+      prsMerged: 0,
+      issuesCreated: 0,
+      bountiedIssuesCount: 0,
+      bountiedIssuesTotal: 0,
+      distinctPrsReviewed: 0,
+    }
 
-  await generateMarkdown(mockPRs, contributorStats, "2024-03-01")
+    const result = getContributorScore(mockPRs, contributorStats)
+    expect(result.score).toBe(0) // Should return 0 for no reviews
+  })
 
-  // Score should be 4 (Major PR) + 0 (no reviews)
-  expect(contributorStats["user1"].score).toBe(4)
+  it("should properly calculate score from distinct PRs reviewed", () => {
+    const mockPRs: AnalyzedPR[] = []
+    const contributorStats: ContributorStats = {
+      reviewsReceived: 0,
+      rejectionsReceived: 0,
+      approvalsReceived: 0,
+      approvalsGiven: 5,
+      rejectionsGiven: 2,
+      prsOpened: 0,
+      prsMerged: 0,
+      issuesCreated: 0,
+      bountiedIssuesCount: 0,
+      bountiedIssuesTotal: 0,
+      distinctPrsReviewed: 5, // 5 different PRs reviewed
+    }
+
+    const result = getContributorScore(mockPRs, contributorStats)
+    expect(result.score).toBe(5) // Should get 5 points for 5 distinct PRs reviewed
+  })
 })


### PR DESCRIPTION
Fixes #75 

# Add distinct PRs reviewed tracking

## Before
```json
{
  "seveibar": {
    "approvalsGiven": 12,
    "rejectionsGiven": 3,
    "score": 31
  }
}
```

## After
```json
{
  "seveibar": {
    "approvalsGiven": 19,
    "rejectionsGiven": 5,
    "distinctPrsReviewed": 24,
    "score": 72
  }
}
```