### PR TITLE
feat(scoring): include GitHub discussions in contributor scoring

### DIFF
--- a/lib/ai/analyzeDiscussionWithClaude.ts
+++ b/lib/ai/analyzeDiscussionWithClaude.ts
@@ -1,0 +1,69 @@
+import { anthropic } from "lib/sdks"
+import type { DiscussionComment, DiscussionContribution } from "../types"
+
+/**
+ * Analyzes a GitHub Discussion comment using Claude AI to determine its quality level
+ * @param comment The discussion comment to analyze
+ * @returns The contribution level assessment
+ */
+export async function analyzeDiscussionWithClaude(
+  comment: DiscussionComment,
+): Promise<DiscussionContribution> {
+  try {
+    const prompt = `Analyze the following GitHub Discussion comment and classify its contribution level as "Participating", "VeryActive", or "ExtremelyActive" based on these criteria:
+
+Participating: Basic participation with minimal effort. Short comments that don't add significant value to the discussion.
+
+VeryActive: Thoughtful participation that adds value. Detailed explanations, helpful suggestions, or meaningful questions that advance the discussion.
+
+ExtremelyActive: Exceptional participation with high-quality content. In-depth analysis, comprehensive explanations, code examples, or solutions that significantly help others.
+
+Discussion Title: ${comment.discussionTitle}
+Comment Body: ${comment.body}
+
+Response format:
+Level: [Participating/VeryActive/ExtremelyActive]
+Reasoning: [Brief explanation of your classification]`
+
+    const message = await anthropic.messages.create({
+      model: "claude-3-haiku-20240307",
+      max_tokens: 100,
+      messages: [{ role: "user", content: prompt }],
+    })
+
+    // @ts-ignore
+    const content = message.content[0].text.trim().toLowerCase()
+    const level =
+      content.split("level:")[1]?.split("reasoning:")[0]?.trim() ??
+      "participating"
+
+    // Map the response to the expected format
+    let contributionLevel: "Participating" | "VeryActive" | "ExtremelyActive" =
+      "Participating"
+
+    if (level.includes("VeryActive".toLowerCase())) {
+      contributionLevel = "VeryActive"
+    } else if (level.includes("ExtremelyActive".toLowerCase())) {
+      contributionLevel = "ExtremelyActive"
+    }
+
+    return {
+      level: contributionLevel,
+      count:
+        contributionLevel === "Participating"
+          ? 1
+          : contributionLevel === "VeryActive"
+            ? 2
+            : 3,
+    }
+  } catch (error) {
+    console.error(
+      `Error analyzing discussion comment for ${comment.discussionUrl}:`,
+      error,
+    )
+    return {
+      level: "Participating",
+      count: 1,
+    }
+  }
+}

--- a/lib/data-retrieval/getAllDiscussionComments.ts
+++ b/lib/data-retrieval/getAllDiscussionComments.ts
@@ -1,0 +1,101 @@
+import { octokit } from "lib/sdks"
+import { graphql } from "@octokit/graphql"
+import type { DiscussionComment } from "lib/types"
+/**
+ * Fetches discussion comments for a specific user in a repository since a given date
+ */
+export async function getAllDiscussionComments(
+  startDate: string,
+  repo: string = "tscircuit/tscircuit",
+): Promise<DiscussionComment[]> {
+  try {
+    const [owner, repoName] = repo.split("/")
+
+    // Create a GraphQL client with authentication
+    const graphqlWithAuth = graphql.defaults({
+      headers: {
+        authorization: `token ${process.env.GITHUB_TOKEN}`,
+      },
+    })
+
+    // Format date for GraphQL query
+    const formattedDate = new Date(startDate).toISOString()
+
+    // Fetch organization discussion comments
+    const query = `
+  query GetOrgDiscussionComments($owner: String!, $repo: String!) {
+    organization(login: $owner) {
+      repository(name: $repo) {
+        discussions(first: 100) {
+          nodes {
+            title
+            url
+            number
+            author {
+              login
+            }
+            bodyText
+            createdAt
+            comments(first: 100) {
+              nodes {
+                author {
+                  login
+                }
+                bodyText
+                createdAt
+                url
+                isAnswer
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+    // Execute the GraphQL query
+    const result: any = await graphqlWithAuth(query, {
+      owner,
+      repo: repoName,
+    })
+
+    // Process and filter the results
+    const discussionComments: DiscussionComment[] = []
+
+    if (result.organization?.repository?.discussions?.nodes) {
+      for (const discussion of result.organization?.repository.discussions
+        .nodes) {
+        if (discussion.comments?.nodes) {
+          discussionComments.push({
+            discussionTitle: discussion.title,
+            discussionNumber: discussion.number,
+            discussionUrl: discussion.url,
+            discussionAuthor: discussion.author?.login,
+            body: discussion.bodyText,
+            url: discussion.url,
+            createdAt: discussion.createdAt,
+          })
+          for (const comment of discussion.comments.nodes) {
+            // Only include comments by the specified user and after the start date
+            if (new Date(comment.createdAt) >= new Date(formattedDate)) {
+              discussionComments.push({
+                discussionTitle: discussion.title,
+                discussionNumber: discussion.number,
+                discussionUrl: discussion.url,
+                body: comment.bodyText,
+                url: comment.url,
+                discussionAuthor: comment.author.login,
+                createdAt: comment.createdAt,
+              })
+            }
+          }
+        }
+      }
+    }
+    return discussionComments
+  } catch (error) {
+    console.error(`Error fetching discussion comments}:`, error)
+    return []
+  }
+}

--- a/lib/data-retrieval/getAllDiscussionComments.ts
+++ b/lib/data-retrieval/getAllDiscussionComments.ts
@@ -1,6 +1,7 @@
 import { octokit } from "lib/sdks"
 import { graphql } from "@octokit/graphql"
 import type { DiscussionComment } from "lib/types"
+
 /**
  * Fetches discussion comments for a specific user in a repository since a given date
  */

--- a/lib/data-retrieval/processDiscussions.ts
+++ b/lib/data-retrieval/processDiscussions.ts
@@ -1,0 +1,59 @@
+import { getAllDiscussionComments } from "./getAllDiscussionComments"
+import { analyzeDiscussionWithClaude } from "../ai/analyzeDiscussionWithClaude"
+import type { ContributorStats } from "lib/types"
+
+export async function processDiscussionsForContributors(
+  startDate: string,
+  contributorsRecord: Record<string, ContributorStats>,
+): Promise<Record<string, ContributorStats>> {
+  const contributorsStats: Record<string, ContributorStats> = JSON.parse(
+    JSON.stringify(contributorsRecord),
+  )
+  try {
+    // Fetch discussion comments for the contributor
+    const discussionComments = await getAllDiscussionComments(startDate)
+    // Analyze each comment and update stats based on contribution level
+    for (const comment of discussionComments) {
+      const analysis = await analyzeDiscussionWithClaude(comment)
+      if (
+        !contributorsStats[comment.discussionAuthor] ||
+        contributorsStats[comment.discussionAuthor]?.discussionComments ===
+          undefined
+      ) {
+        contributorsStats[comment.discussionAuthor] = {
+          discussionComments: 0,
+          discussionParticipating: 0,
+          discussionVeryActive: 0,
+          discussionExtremelyActive: 0,
+          ...contributorsStats[comment.discussionAuthor],
+        }
+      }
+      contributorsStats[comment.discussionAuthor].discussionComments =
+        (contributorsStats[comment.discussionAuthor]?.discussionComments || 0) +
+        1
+      switch (analysis.level) {
+        case "Participating":
+          contributorsStats[comment.discussionAuthor].discussionParticipating =
+            (contributorsStats[comment.discussionAuthor]
+              ?.discussionParticipating || 0) + 1
+          break
+        case "VeryActive":
+          contributorsStats[comment.discussionAuthor].discussionVeryActive =
+            (contributorsStats[comment.discussionAuthor]
+              ?.discussionVeryActive || 0) + 1
+          break
+        case "ExtremelyActive":
+          contributorsStats[
+            comment.discussionAuthor
+          ].discussionExtremelyActive =
+            (contributorsStats[comment.discussionAuthor]
+              ?.discussionExtremelyActive || 0) + 1
+          break
+      }
+    }
+    return contributorsStats
+  } catch (error) {
+    console.error(`Error processing discussions:`, error)
+    return contributorsRecord
+  }
+}

--- a/lib/scoring/getContributorScore.ts
+++ b/lib/scoring/getContributorScore.ts
@@ -8,7 +8,7 @@ export interface ContributorScore {
 }
 
 /**
- * Calculate score for a contributor based on PRs, issues, and reviews
+ * Calculate score for a contributor based on PRs, issues, reviews, and discussions
  */
 export function getContributorScore(
   contributorPRs: AnalyzedPR[],

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,21 @@ export interface ReviewerStats {
   prNumbers?: Set<number> // Set of PR numbers this reviewer has reviewed
 }
 
+export interface DiscussionComment {
+  discussionTitle: string
+  discussionNumber: number
+  discussionUrl: string
+  body: string
+  url: string
+  createdAt: string
+  discussionAuthor: string
+}
+
+export interface DiscussionContribution {
+  level: "Participating" | "VeryActive" | "ExtremelyActive"
+  count: number
+}
+
 export interface ContributorStats {
   reviewsReceived: number
   rejectionsReceived: number
@@ -21,6 +36,10 @@ export interface ContributorStats {
   minor?: number // Count of Minor PRs
   tiny?: number // Count of Tiny PRs
   stars?: string // Either "⭐" or "👑" based on score
+  discussionComments?: number // Total number of discussion comments
+  discussionParticipating?: number // Count of "Participating" level comments
+  discussionVeryActive?: number // Count of "Very Active" level comments
+  discussionExtremelyActive?: number // Count of "Extremely Active" level comments
 }
 
 export interface PullRequest {


### PR DESCRIPTION
Add support for analyzing and scoring GitHub discussion contributions. This includes fetching discussion comments, classifying their quality using Claude AI, and updating the contributor scoring system to reflect participation levels (Participating, VeryActive, ExtremelyActive). The markdown report has been updated to display discussion contributions alongside PRs and issues.


###### /claim #102