### PR TITLE
fix(generateMarkdown): display contributor score as stars instead of dash

### DIFF
--- a/lib/data-processing/generateMarkdown.ts
+++ b/lib/data-processing/generateMarkdown.ts
@@ -162,7 +162,7 @@ export async function generateMarkdown(
     markdown += `| [${contributor}](#${contributor.replace(
       /\s/g,
       "-",
-    )}) | 0 | 0 | 0 | - | ${
+    )}) | 0 | 0 | 0 | ${scoreToStarString(stats.score || 0)} | ${
       stats?.issuesCreated ?? 0
     } | ${discussionSummary} |\n`
   }


### PR DESCRIPTION
Previously, the score column in the markdown table displayed a dash for contributor scores. This change replaces the dash with a star representation of the score using the `scoreToStarString` function to provide more meaningful feedback on contributor performance.