### PR TITLE
feat: add major tag detection for pull requests

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -109,6 +109,9 @@ export async function generateOverview(startDate: string) {
         continue
       }
       const analysis = await analyzePRWithClaude(pr, repo)
+      if (pr.hasMajorTag) {
+        analysis.impact = "Major"
+      }
       mergedPrsWithAnalysis.push(analysis)
     }
 

--- a/lib/data-retrieval/getMergedPRs.ts
+++ b/lib/data-retrieval/getMergedPRs.ts
@@ -30,17 +30,15 @@ export async function getMergedPRs(
         mediaType: { format: "diff" },
       })
 
-      // Check if PR has /major tag in title or body
-      const hasMajorTag =
-        (pr.title && pr.title.includes("/major")) ||
-        (pr.body && pr.body.includes("/major"))
-
       // Fetch comments for the PR
-      const { data: comments } = await octokit.issues.listComments({
-        owner,
-        repo: repo_name,
-        issue_number: pr.number,
-      })
+      const { data: comments } = await octokit.issues
+        .listComments({
+          owner,
+          repo: repo_name,
+          issue_number: pr.number,
+          per_page: 100,
+        })
+        .catch(() => ({ data: [] }))
 
       // Check if any maintainer has added a /major tag in their comments
       const hasMajorTagFromMaintainer = comments.some(
@@ -49,11 +47,10 @@ export async function getMergedPRs(
           comment.body &&
           comment.body.includes("/major"),
       )
-
       return {
         ...pr,
         diff: diffData as unknown as string,
-        hasMajorTag: hasMajorTag || hasMajorTagFromMaintainer,
+        hasMajorTag: hasMajorTagFromMaintainer,
       }
     }),
   )

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,7 @@ export interface PullRequest {
 
 export interface MergedPullRequest extends PullRequest {
   diff: string
+  hasMajorTag?: boolean
 }
 
 export interface PullRequestWithReviews extends PullRequest {


### PR DESCRIPTION
Introduce functionality to detect `/major` tags in **merged pull requests**, including checks in titles, bodies, and maintainer comments. This allows for automatic impact classification of PRs based on the presence of the tag.

resolve #83 