### PR TITLE
refactor(contributor): add discussion metrics and scoring to contributor stats

### DIFF
--- a/frontend/src/types/contributor.ts
+++ b/frontend/src/types/contributor.ts
@@ -14,6 +14,11 @@ export interface ContributorStats {
   tiny?: number
   stars?: string
   score?: number
+  distinctPrsReviewed?: number
+  discussionComments?: number
+  discussionParticipating?: number
+  discussionVeryActive?: number
+  discussionExtremelyActive?: number
 }
 
 export interface ContributorCardProps {

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,10 @@
 import * as fs from "fs"
 import type { AnalyzedPR, ContributorStats } from "lib/types"
 import { getRepos } from "lib/data-retrieval/getRepos"
-import { generateMarkdown } from "lib/data-processing/generateMarkdown"
+import {
+  generateMarkdown,
+  scoreToStarString,
+} from "lib/data-processing/generateMarkdown"
 import { getMergedPRs } from "lib/data-retrieval/getMergedPRs"
 import { getAllPRs } from "lib/data-retrieval/getAllPRs"
 import { getBountiedIssues } from "lib/data-retrieval/getBountiedIssues"
@@ -168,6 +171,7 @@ export async function generateOverview(startDate: string) {
           bountiedIssuesCount: 0,
           bountiedIssuesTotal: 0,
           distinctPrsReviewed: 0,
+          score: 0,
         }
       }
       if (contributorData[contributor].discussionComments === undefined) {
@@ -184,6 +188,23 @@ export async function generateOverview(startDate: string) {
         allGithubDiscussions[contributor].discussionVeryActive
       contributorData[contributor].discussionExtremelyActive =
         allGithubDiscussions[contributor].discussionExtremelyActive
+
+      // Add to score based on discussion contribution levels
+
+      contributorData[contributor].score =
+        (contributorData[contributor].score ?? 0) +
+        (contributorData[contributor].discussionParticipating ?? 0) * 25 // 1 point each
+      contributorData[contributor].score =
+        (contributorData[contributor].score ?? 0) +
+        (contributorData[contributor].discussionVeryActive ?? 0) * 2 // 2 points each
+      contributorData[contributor].score =
+        (contributorData[contributor].score ?? 0) +
+        (contributorData[contributor].discussionExtremelyActive ?? 0) * 4 // 4 points each
+
+      console.log("3434", contributorData[contributor].score)
+      contributorData[contributor].stars = scoreToStarString(
+        contributorData[contributor].score ?? 0,
+      )
     },
   )
   await Promise.all(processDiscussionsPromises)

--- a/index.ts
+++ b/index.ts
@@ -201,7 +201,6 @@ export async function generateOverview(startDate: string) {
         (contributorData[contributor].score ?? 0) +
         (contributorData[contributor].discussionExtremelyActive ?? 0) * 4 // 4 points each
 
-      console.log("3434", contributorData[contributor].score)
       contributorData[contributor].stars = scoreToStarString(
         contributorData[contributor].score ?? 0,
       )

--- a/index.ts
+++ b/index.ts
@@ -193,7 +193,7 @@ export async function generateOverview(startDate: string) {
 
       contributorData[contributor].score =
         (contributorData[contributor].score ?? 0) +
-        (contributorData[contributor].discussionParticipating ?? 0) * 25 // 1 point each
+        (contributorData[contributor].discussionParticipating ?? 0) * 1 // 1 point each
       contributorData[contributor].score =
         (contributorData[contributor].score ?? 0) +
         (contributorData[contributor].discussionVeryActive ?? 0) * 2 // 2 points each

--- a/lib/data-retrieval/getAllDiscussionComments.ts
+++ b/lib/data-retrieval/getAllDiscussionComments.ts
@@ -1,4 +1,3 @@
-import { octokit } from "lib/sdks"
 import { graphql } from "@octokit/graphql"
 import type { DiscussionComment } from "lib/types"
 
@@ -94,7 +93,9 @@ export async function getAllDiscussionComments(
         }
       }
     }
-    return discussionComments
+    return discussionComments.filter(
+      (comment) => new Date(comment.createdAt) >= new Date(formattedDate),
+    )
   } catch (error) {
     console.error(`Error fetching discussion comments}:`, error)
     return []


### PR DESCRIPTION
resolve #117
This commit introduces new fields to the `ContributorStats` interface to track discussion participation levels (`discussionParticipating`, `discussionVeryActive`, `discussionExtremelyActive`) and related metrics (`distinctPrsReviewed`, `discussionComments`). It also implements a scoring system based on these metrics, converting the score to a star rating using `scoreToStarString`. Additionally, the `getAllDiscussionComments` function is refactored to filter comments by date, improving data retrieval efficiency.