### PR TITLE
feat: add storePrAnalysis function to save analyzed PRs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { getIssuesCreated } from "lib/data-retrieval/getIssuesCreated"
 import { analyzePRWithClaude } from "lib/ai/analyzePRWithClaude"
 import { getLastWednesday } from "lib/ai/date-utils"
 import { processDiscussionsForContributors } from "lib/data-retrieval/processDiscussions"
+import { storePrAnalysis } from "lib/data-processing/storePrAnalysis"
 
 export async function generateOverview(startDate: string) {
   const startDateString = startDate
@@ -111,6 +112,8 @@ export async function generateOverview(startDate: string) {
       const analysis = await analyzePRWithClaude(pr, repo)
       mergedPrsWithAnalysis.push(analysis)
     }
+
+    storePrAnalysis(mergedPrsWithAnalysis, startDate)
 
     // Fetch and process bountied issues for all contributors in parallel
     const bountiedIssuesPromises = Object.keys(contributorData).map(

--- a/lib/data-processing/storePrAnalysis.ts
+++ b/lib/data-processing/storePrAnalysis.ts
@@ -1,0 +1,26 @@
+import type { AnalyzedPR } from "lib/types"
+import fs from "fs"
+export const storePrAnalysis = (
+  mergedPrsWithAnalysis: AnalyzedPR[],
+  startDate: string,
+) => {
+  // Ensure directory exists before writing
+  const dir = "pr-analysis"
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+
+  fs.writeFileSync(
+    `${dir}/${startDate}.json`,
+    JSON.stringify(
+      mergedPrsWithAnalysis.map((pr) => ({
+        tag: `${pr.repo}#${pr.number}`,
+        ...pr,
+      })),
+      null,
+      2,
+    ),
+    {},
+  )
+  console.log(`Generated pr-analysis/${startDate}.json`)
+}

--- a/lib/data-processing/storePrAnalysis.ts
+++ b/lib/data-processing/storePrAnalysis.ts
@@ -2,7 +2,7 @@ import type { AnalyzedPR } from "lib/types"
 import fs from "fs"
 export const storePrAnalysis = (
   mergedPrsWithAnalysis: AnalyzedPR[],
-  startDate: string,
+  weekStartDate: string,
 ) => {
   // Ensure directory exists before writing
   const dir = "pr-analysis"
@@ -11,7 +11,7 @@ export const storePrAnalysis = (
   }
 
   fs.writeFileSync(
-    `${dir}/${startDate}.json`,
+    `${dir}/${weekStartDate}.json`,
     JSON.stringify(
       mergedPrsWithAnalysis.map((pr) => ({
         tag: `${pr.repo}#${pr.number}`,
@@ -20,7 +20,6 @@ export const storePrAnalysis = (
       null,
       2,
     ),
-    {},
   )
-  console.log(`Generated pr-analysis/${startDate}.json`)
+  console.log(`Generated pr-analysis/${weekStartDate}.json`)
 }


### PR DESCRIPTION
Introduce a new function `storePrAnalysis` to save analyzed PR data to a JSON file. This function ensures the output directory exists and writes the data in a structured format. The function is integrated into the `generateOverview` process to persist PR analysis results.