### PR TITLE
Enhance PR filtering to exclude reverted pull requests

### DIFF
--- a/lib/data-retrieval/getMergedPRs.ts
+++ b/lib/data-retrieval/getMergedPRs.ts
@@ -17,7 +17,11 @@ export async function getMergedPRs(
   })
 
   const filteredPRs = data.filter(
-    (pr) => pr.merged_at && new Date(pr.merged_at) >= new Date(since),
+    (pr) =>
+      pr.merged_at &&
+      new Date(pr.merged_at) >= new Date(since) &&
+      !pr.title.includes("Revert") &&
+      (pr.body ? !pr.body.toLowerCase().includes("reverts") : true),
   )
 
   // Fetch diff content for each PR

--- a/lib/data-retrieval/getMergedPRs.ts
+++ b/lib/data-retrieval/getMergedPRs.ts
@@ -20,8 +20,8 @@ export async function getMergedPRs(
     (pr) =>
       pr.merged_at &&
       new Date(pr.merged_at) >= new Date(since) &&
-      !pr.title.includes("Revert") &&
-      (pr.body ? !pr.body.toLowerCase().includes("reverts") : true),
+      !pr.title?.toLowerCase().includes("revert") &&
+      (pr.body ? !pr.body?.toLowerCase().includes("revert") : true),
   )
 
   // Fetch diff content for each PR


### PR DESCRIPTION
fix #126 

instead it wouldnt even count revert prs