### PR TITLE
feat(modal): add support for closing modal with Escape key

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useCallback } from "react"
 import { X } from "lucide-react"
 
 interface ModalProps {
@@ -8,6 +9,25 @@ interface ModalProps {
 }
 
 export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose()
+      }
+    },
+    [onClose],
+  )
+
+  useEffect(() => {
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown)
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [isOpen, handleKeyDown])
+
   if (!isOpen) return null
 
   return (


### PR DESCRIPTION
Added an event listener to handle the 'Escape' key press, allowing users to close the modal using the keyboard. Utilized useCallback for efficient event handling.

fix #144