### PR TITLE
docs(prompts): update PR assessment description to exclude hyperlinks

### DIFF
--- a/lib/ai-stuff/prompts.ts
+++ b/lib/ai-stuff/prompts.ts
@@ -86,6 +86,7 @@ Strictly assess the PR across the following dimensions:
    - "Solves discord bug where user can't see boards with many traces inside RunFrame preview"
    - "Add Mosfet symbol"
    - "Fixes KiCad symbol export when jumper is misaligned"
+   - Do not include any hyperlinks, or image links, just use plain text
 </description>
 
 ${Object.entries(PR_ATTRIBUTES)


### PR DESCRIPTION

<img width="1071" height="213" alt="image" src="https://github.com/user-attachments/assets/15479c9b-a3af-4ae4-873b-f18c0e6ab703" />

Clarify that PR assessment descriptions should use plain text only without any hyperlinks or image links to maintain consistency in output format.