### PR TITLE
fix: exclude bot accounts from contributor data

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -299,6 +299,13 @@ export async function generateOverview(startDate: string) {
   )
   await Promise.all(processDiscussionsPromises)
 
+  // Remove bot accounts from contributor data
+  Object.keys(contributorData).forEach((contributor) => {
+    if (contributor.includes("[bot]")) {
+      delete contributorData[contributor]
+    }
+  })
+
   // Data processing complete
   await generateAndWriteFiles(
     mergedPrsWithAnalysis,


### PR DESCRIPTION
Filter out bot accounts from contributor statistics by checking for "[bot]" in usernames to ensure accurate reporting