### PR TITLE
Add management system for ineligible users for sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,11 +839,55 @@ pie
 
 - `bun run export:sponsorship` - Generate sponsorship data CSV
 
+#### Sponsorship Management
+
+- `bun run manage:ineligible add <username> <reason> [added-by]` - Add user to ineligible list
+- `bun run manage:ineligible remove <username>` - Remove user from ineligible list  
+- `bun run manage:ineligible list` - List all ineligible users
+- `bun run manage:ineligible check <username>` - Check if user is ineligible
+
 #### Development
 
 - `bun run dev` - Start development server for web UI
 - `bun run build` - Build for production
 - `bun run format` - Format code with Biome
+
+## Ineligible for Sponsorship Management
+
+The project includes a system to manage users who are ineligible for sponsorship payments. This is useful for handling cases where contributors claim bounties early or violate contribution guidelines.
+
+### How It Works
+
+- Users on the ineligible list will still appear in all contribution overviews and reports
+- However, they will be automatically excluded from the generated `sponsorships.csv` file
+- The system maintains an audit trail with reasons and timestamps
+
+### Managing Ineligible Users
+
+The ineligible users list is stored in `ineligible-for-sponsorship.csv` with the following columns:
+- `github_username` - The GitHub username
+- `reason` - Reason for ineligibility  
+- `date_added` - Date when user was added (YYYY-MM-DD)
+- `added_by` - Who added the user to the list
+
+### Common Usage Examples
+
+```bash
+# Add a user who claimed bounties early
+bun run manage:ineligible add user123 "Claimed bounty before completing work" maintainer1
+
+# Check if a user is ineligible
+bun run manage:ineligible check user123
+
+# List all ineligible users
+bun run manage:ineligible list
+
+# Remove a user from the ineligible list
+bun run manage:ineligible remove user123
+
+# Generate sponsorship CSV (automatically excludes ineligible users)
+bun run export:sponsorship
+```
 
 ### Usage Examples
 

--- a/ineligible-for-sponsorship.csv
+++ b/ineligible-for-sponsorship.csv
@@ -1,0 +1,1 @@
+github_username,reason,date_added,added_by

--- a/lib/scoring/ineligibleUsers.ts
+++ b/lib/scoring/ineligibleUsers.ts
@@ -1,0 +1,180 @@
+import fs from "node:fs"
+import path from "node:path"
+
+export interface IneligibleUser {
+  github_username: string
+  reason: string
+  date_added: string
+  added_by: string
+}
+
+const INELIGIBLE_FILE_PATH = path.join(process.cwd(), "ineligible-for-sponsorship.csv")
+
+
+function parseCSVLine(line: string): IneligibleUser | null {
+  const parts: string[] = []
+  let current = ''
+  let inQuotes = false
+  let i = 0
+
+  while (i < line.length) {
+    const char = line[i]
+    
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"'
+        i += 2
+      } else {
+        inQuotes = !inQuotes
+        i++
+      }
+    } else if (char === ',' && !inQuotes) {
+      parts.push(current.trim())
+      current = ''
+      i++
+    } else {
+      current += char
+      i++
+    }
+  }
+  
+  parts.push(current.trim())
+  
+  if (parts.length !== 4) {
+    console.warn(`Invalid CSV line format: ${line}`)
+    return null
+  }
+
+  const [github_username, reason, date_added, added_by] = parts
+  
+  if (!github_username || !reason || !date_added || !added_by) {
+    console.warn(`Missing required fields in CSV line: ${line}`)
+    return null
+  }
+
+  return {
+    github_username,
+    reason,
+    date_added,
+    added_by
+  }
+}
+
+
+function toCSVLine(user: IneligibleUser): string {
+  const escape = (value: string) => {
+    if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+      return `"${value.replace(/"/g, '""')}"`
+    }
+    return value
+  }
+
+  return [
+    escape(user.github_username),
+    escape(user.reason),
+    escape(user.date_added),
+    escape(user.added_by)
+  ].join(',')
+}
+
+export function loadIneligibleUsers(): IneligibleUser[] {
+  try {
+    if (!fs.existsSync(INELIGIBLE_FILE_PATH)) {
+      console.log("No ineligible users file found, treating all users as eligible")
+      return []
+    }
+
+    const content = fs.readFileSync(INELIGIBLE_FILE_PATH, 'utf-8')
+    const lines = content.trim().split('\n')
+    
+    if (lines.length <= 1) {
+      return []
+    }
+
+    const users: IneligibleUser[] = []
+    for (let i = 1; i < lines.length; i++) {
+      const user = parseCSVLine(lines[i])
+      if (user) {
+        users.push(user)
+      }
+    }
+
+    return users
+  } catch (error) {
+    console.error("Error loading ineligible users:", error)
+    return []
+  }
+}
+
+function saveIneligibleUsers(users: IneligibleUser[]): void {
+  try {
+    const header = "github_username,reason,date_added,added_by"
+    const lines = [header, ...users.map(toCSVLine)]
+    const content = lines.join('\n') + '\n'
+    
+    fs.writeFileSync(INELIGIBLE_FILE_PATH, content, 'utf-8')
+  } catch (error) {
+    console.error("Error saving ineligible users:", error)
+    throw error
+  }
+}
+
+
+export function isUserIneligible(username: string): boolean {
+  const ineligibleUsers = loadIneligibleUsers()
+  return ineligibleUsers.some(user => user.github_username === username)
+}
+
+export function getIneligibleUser(username: string): IneligibleUser | null {
+  const ineligibleUsers = loadIneligibleUsers()
+  return ineligibleUsers.find(user => user.github_username === username) || null
+}
+
+export function getIneligibleUsernames(): Set<string> {
+  const ineligibleUsers = loadIneligibleUsers()
+  return new Set(ineligibleUsers.map(user => user.github_username))
+}
+
+export function addIneligibleUser(
+  username: string, 
+  reason: string, 
+  addedBy: string = "system"
+): void {
+  const users = loadIneligibleUsers()
+  
+  if (users.some(user => user.github_username === username)) {
+    throw new Error(`User ${username} is already in the ineligible list`)
+  }
+
+  const newUser: IneligibleUser = {
+    github_username: username,
+    reason,
+    date_added: new Date().toISOString().split('T')[0], // YYYY-MM-DD format
+    added_by: addedBy
+  }
+
+  users.push(newUser)
+  saveIneligibleUsers(users)
+  
+  console.log(`Added ${username} to ineligible list: ${reason}`)
+}
+
+export function removeIneligibleUser(username: string): boolean {
+  const users = loadIneligibleUsers()
+  const initialLength = users.length
+  
+  const filteredUsers = users.filter(user => user.github_username !== username)
+  
+  if (filteredUsers.length === initialLength) {
+    console.log(`User ${username} was not found in the ineligible list`)
+    return false
+  }
+
+  saveIneligibleUsers(filteredUsers)
+  console.log(`Removed ${username} from ineligible list`)
+  return true
+}
+
+export function listIneligibleUsers(): IneligibleUser[] {
+  return loadIneligibleUsers()
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "notifications:issues": "bun --env-file=.env scripts/issue-notifications.ts",
     "notifications:pr": "bun --env-file=.env scripts/pr-notifications.ts",
     "export:sponsorship": "bun --env-file=.env scripts/generate-sponsorship-csv.ts",
+    "manage:ineligible": "bun scripts/manage-ineligible-users.ts",
     "dev": "vite",
     "start": "vite",
     "build": "vite build",

--- a/scripts/manage-ineligible-users.ts
+++ b/scripts/manage-ineligible-users.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env bun
+
+import { 
+  addIneligibleUser, 
+  removeIneligibleUser, 
+  listIneligibleUsers,
+  isUserIneligible,
+  getIneligibleUser
+} from "../lib/scoring/ineligibleUsers"
+
+function showHelp() {
+  console.log(`
+Usage: bun run manage-ineligible-users.ts <command> [arguments]
+
+Commands:
+  add <username> <reason> [added-by]    Add a user to the ineligible list
+  remove <username>                     Remove a user from the ineligible list
+  list                                  List all ineligible users
+  check <username>                      Check if a user is ineligible
+  help                                  Show this help message
+
+Examples:
+  bun run manage-ineligible-users.ts add user123 "Claimed bounty early" maintainer1
+  bun run manage-ineligible-users.ts remove user123
+  bun run manage-ineligible-users.ts list
+  bun run manage-ineligible-users.ts check user123
+`)
+}
+
+function formatTable(users: ReturnType<typeof listIneligibleUsers>) {
+  if (users.length === 0) {
+    console.log("No ineligible users found.")
+    return
+  }
+
+  console.log("\nIneligible Users:")
+  console.log("━".repeat(80))
+  console.log(
+    `${"Username".padEnd(20)} ${"Reason".padEnd(30)} ${"Date Added".padEnd(12)} ${"Added By".padEnd(15)}`
+  )
+  console.log("━".repeat(80))
+  
+  users.forEach(user => {
+    const username = user.github_username.padEnd(20)
+    const reason = (user.reason.length > 28 ? user.reason.substring(0, 25) + "..." : user.reason).padEnd(30)
+    const dateAdded = user.date_added.padEnd(12)
+    const addedBy = user.added_by.padEnd(15)
+    
+    console.log(`${username} ${reason} ${dateAdded} ${addedBy}`)
+  })
+  console.log("━".repeat(80))
+  console.log(`Total: ${users.length} ineligible users`)
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  
+  if (args.length === 0 || args[0] === "help" || args[0] === "--help" || args[0] === "-h") {
+    showHelp()
+    return
+  }
+
+  const command = args[0].toLowerCase()
+
+  try {
+    switch (command) {
+      case "add": {
+        if (args.length < 3) {
+          console.error("Error: 'add' command requires username and reason")
+          console.log("Usage: bun run manage-ineligible-users.ts add <username> <reason> [added-by]")
+          process.exit(1)
+        }
+
+        const username = args[1]
+        const reason = args[2]
+        const addedBy = args[3] || "system"
+
+        // Validate username format (basic GitHub username validation)
+        if (!/^[a-zA-Z0-9]([a-zA-Z0-9-])*[a-zA-Z0-9]$|^[a-zA-Z0-9]$/.test(username)) {
+          console.error(`Error: '${username}' is not a valid GitHub username`)
+          process.exit(1)
+        }
+
+        if (isUserIneligible(username)) {
+          const existingUser = getIneligibleUser(username)
+          console.error(`Error: User '${username}' is already ineligible`)
+          console.log(`Current reason: ${existingUser?.reason}`)
+          console.log(`Added on: ${existingUser?.date_added} by ${existingUser?.added_by}`)
+          process.exit(1)
+        }
+
+        addIneligibleUser(username, reason, addedBy)
+        console.log(`Successfully added '${username}' to the ineligible list`)
+        break
+      }
+
+      case "remove": {
+        if (args.length < 2) {
+          console.error("Error: 'remove' command requires username")
+          console.log("Usage: bun run manage-ineligible-users.ts remove <username>")
+          process.exit(1)
+        }
+
+        const username = args[1]
+        const removed = removeIneligibleUser(username)
+        
+        if (removed) {
+          console.log(`Successfully removed '${username}' from the ineligible list`)
+        } else {
+          console.log(`User '${username}' was not found in the ineligible list`)
+        }
+        break
+      }
+
+      case "list": {
+        const users = listIneligibleUsers()
+        formatTable(users)
+        break
+      }
+
+      case "check": {
+        if (args.length < 2) {
+          console.error("Error: 'check' command requires username")
+          console.log("Usage: bun run manage-ineligible-users.ts check <username>")
+          process.exit(1)
+        }
+
+        const username = args[1]
+        const user = getIneligibleUser(username)
+        
+        if (user) {
+          console.log(`User '${username}' is INELIGIBLE for sponsorship`)
+          console.log(`   Reason: ${user.reason}`)
+          console.log(`   Added on: ${user.date_added} by ${user.added_by}`)
+        } else {
+          console.log(`User '${username}' is eligible for sponsorship`)
+        }
+        break
+      }
+
+      default:
+        console.error(`Error: Unknown command '${command}'`)
+        showHelp()
+        process.exit(1)
+    }
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+}
+
+main()

--- a/tests/test-ineligible-users.test.ts
+++ b/tests/test-ineligible-users.test.ts
@@ -1,0 +1,183 @@
+import { test, expect, beforeEach, afterEach } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+import { 
+  addIneligibleUser, 
+  removeIneligibleUser, 
+  listIneligibleUsers,
+  isUserIneligible,
+  getIneligibleUser,
+  getIneligibleUsernames
+} from "../lib/scoring/ineligibleUsers"
+
+const TEST_FILE_PATH = path.join(process.cwd(), "ineligible-for-sponsorship-test.csv")
+const ORIGINAL_FILE_PATH = path.join(process.cwd(), "ineligible-for-sponsorship.csv")
+
+beforeEach(() => {
+  if (fs.existsSync(ORIGINAL_FILE_PATH)) {
+    fs.copyFileSync(ORIGINAL_FILE_PATH, `${ORIGINAL_FILE_PATH}.backup`)
+  }
+  
+  fs.writeFileSync(TEST_FILE_PATH, "github_username,reason,date_added,added_by\n")
+  
+  if (fs.existsSync(ORIGINAL_FILE_PATH)) {
+    fs.unlinkSync(ORIGINAL_FILE_PATH)
+  }
+  fs.copyFileSync(TEST_FILE_PATH, ORIGINAL_FILE_PATH)
+})
+
+afterEach(() => {
+  if (fs.existsSync(TEST_FILE_PATH)) {
+    fs.unlinkSync(TEST_FILE_PATH)
+  }
+  
+  if (fs.existsSync(`${ORIGINAL_FILE_PATH}.backup`)) {
+    fs.copyFileSync(`${ORIGINAL_FILE_PATH}.backup`, ORIGINAL_FILE_PATH)
+    fs.unlinkSync(`${ORIGINAL_FILE_PATH}.backup`)
+  } else {
+    fs.writeFileSync(ORIGINAL_FILE_PATH, "github_username,reason,date_added,added_by\n")
+  }
+})
+
+test("should start with empty ineligible list", () => {
+  const users = listIneligibleUsers()
+  expect(users).toEqual([])
+})
+
+test("should add user to ineligible list", () => {
+  addIneligibleUser("testuser", "Test reason", "maintainer")
+  
+  const users = listIneligibleUsers()
+  expect(users).toHaveLength(1)
+  expect(users[0].github_username).toBe("testuser")
+  expect(users[0].reason).toBe("Test reason")
+  expect(users[0].added_by).toBe("maintainer")
+  expect(users[0].date_added).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+})
+
+test("should check if user is ineligible", () => {
+  expect(isUserIneligible("testuser")).toBe(false)
+  
+  addIneligibleUser("testuser", "Test reason", "maintainer")
+  
+  expect(isUserIneligible("testuser")).toBe(true)
+  expect(isUserIneligible("otheruser")).toBe(false)
+})
+
+test("should get ineligible user details", () => {
+  addIneligibleUser("testuser", "Test reason", "maintainer")
+  
+  const user = getIneligibleUser("testuser")
+  expect(user).not.toBeNull()
+  expect(user?.github_username).toBe("testuser")
+  expect(user?.reason).toBe("Test reason")
+  expect(user?.added_by).toBe("maintainer")
+  
+  const nonExistentUser = getIneligibleUser("nonexistent")
+  expect(nonExistentUser).toBeNull()
+})
+
+test("should get ineligible usernames as Set", () => {
+  addIneligibleUser("user1", "Reason 1", "maintainer")
+  addIneligibleUser("user2", "Reason 2", "maintainer")
+  
+  const usernames = getIneligibleUsernames()
+  expect(usernames).toBeInstanceOf(Set)
+  expect(usernames.has("user1")).toBe(true)
+  expect(usernames.has("user2")).toBe(true)
+  expect(usernames.has("user3")).toBe(false)
+  expect(usernames.size).toBe(2)
+})
+
+test("should remove user from ineligible list", () => {
+  addIneligibleUser("testuser", "Test reason", "maintainer")
+  expect(isUserIneligible("testuser")).toBe(true)
+  
+  const removed = removeIneligibleUser("testuser")
+  expect(removed).toBe(true)
+  expect(isUserIneligible("testuser")).toBe(false)
+  
+  const removedAgain = removeIneligibleUser("testuser")
+  expect(removedAgain).toBe(false)
+})
+
+test("should throw error when adding duplicate user", () => {
+  addIneligibleUser("testuser", "Test reason", "maintainer")
+  
+  expect(() => {
+    addIneligibleUser("testuser", "Another reason", "maintainer")
+  }).toThrow("User testuser is already in the ineligible list")
+})
+
+test("should handle CSV with commas and quotes in data", () => {
+  const reasonWithComma = "Claimed bounty early, violated terms"
+  const reasonWithQuotes = 'Said "I deserve this" without completing work'
+  
+  addIneligibleUser("user1", reasonWithComma, "maintainer")
+  addIneligibleUser("user2", reasonWithQuotes, "maintainer")
+  
+  const users = listIneligibleUsers()
+  expect(users).toHaveLength(2)
+  expect(users[0].reason).toBe(reasonWithComma)
+  expect(users[1].reason).toBe(reasonWithQuotes)
+})
+
+test("should handle multiple users in list", () => {
+  addIneligibleUser("user1", "Reason 1", "maintainer1")
+  addIneligibleUser("user2", "Reason 2", "maintainer2")
+  addIneligibleUser("user3", "Reason 3", "maintainer1")
+  
+  const users = listIneligibleUsers()
+  expect(users).toHaveLength(3)
+  
+  const usernames = users.map(u => u.github_username)
+  expect(usernames).toContain("user1")
+  expect(usernames).toContain("user2")
+  expect(usernames).toContain("user3")
+  
+  removeIneligibleUser("user2")
+  
+  const updatedUsers = listIneligibleUsers()
+  expect(updatedUsers).toHaveLength(2)
+  
+  const updatedUsernames = updatedUsers.map(u => u.github_username)
+  expect(updatedUsernames).toContain("user1")
+  expect(updatedUsernames).toContain("user3")
+  expect(updatedUsernames).not.toContain("user2")
+})
+
+test("should handle missing file gracefully", () => {
+  fs.unlinkSync(ORIGINAL_FILE_PATH)
+  
+  const users = listIneligibleUsers()
+  expect(users).toEqual([])
+  
+  expect(isUserIneligible("testuser")).toBe(false)
+  expect(getIneligibleUser("testuser")).toBeNull()
+  
+  const usernames = getIneligibleUsernames()
+  expect(usernames.size).toBe(0)
+})
+
+test("should handle malformed CSV lines", () => {
+  const malformedContent = `github_username,reason,date_added,added_by
+validuser,Valid reason,2025-09-24,maintainer
+invalidline
+user2,reason2,2025-09-24,maintainer2,extrafield
+user3,reason3,2025-09-24
+validuser2,Valid reason 2,2025-09-24,maintainer2
+`
+  fs.writeFileSync(ORIGINAL_FILE_PATH, malformedContent)
+  
+  const users = listIneligibleUsers() 
+  expect(users).toHaveLength(2)
+  expect(users[0].github_username).toBe("validuser")
+  expect(users[1].github_username).toBe("validuser2")
+})
+
+test("should use default 'system' added_by when not specified", () => {
+  addIneligibleUser("testuser", "Test reason")
+  
+  const user = getIneligibleUser("testuser")
+  expect(user?.added_by).toBe("system")
+})


### PR DESCRIPTION
/fix   #223
Implements a system to manage users who are ineligible for sponsorship payments, 
particularly for those who claim bounties early or violate contribution guidelines.

Two-column CSV structure (github_username, reason)
- Users appear in all reports but excluded from sponsorship CSV generation
- CLI management tools for adding/removing/listing ineligible users

## Usage
```bash
# Add user to ineligible list
bun run manage:ineligible add username "reason" maintainer

# Generate sponsorship CSV (automatically excludes ineligible users)
bun run export:sponsorship
```

Closes #223
