### PR TITLE
Fix automatically link PR references in monthly changelogs

### DIFF
--- a/scripts/generate-monthly-changelog.ts
+++ b/scripts/generate-monthly-changelog.ts
@@ -48,35 +48,12 @@ async function main() {
 
   const prompt = `Create a concise bullet point changelog highlighting the key pull requests from ${year}-${month.toString().padStart(2, "0")}.\n${summaries.join("\n")}\n\n##Guidelines: ${GUIDELINES.map((g) => `- ${g}`).join("\n")}`
 
-  // OpenRouter for testing (DO NOT PUSH THIS)
-  const client = new OpenAI({
-    baseURL: "https://openrouter.ai/api/v1",
-    apiKey: "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",
+  const schema = z.object({ changelog: z.string() })
+  const { object } = await generateAiObjectCached({
+    schema,
+    prompt,
+    model: openai("o3"),
   })
-
-  const completion = await client.chat.completions.create({
-    extra_headers: {
-      "HTTP-Referer": "https://github.com/tscircuit/contribution-tracker",
-      "X-Title": "tscircuit-contribution-tracker",
-    },
-    model: "meta-llama/llama-3.3-8b-instruct:free",
-    messages: [
-      {
-        role: "user",
-        content: prompt,
-      },
-    ],
-  })
-
-  const object = { changelog: completion.choices[0].message.content }
-
-  // Original code (for when pushing):
-  // const schema = z.object({ changelog: z.string() })
-  // const { object } = await generateAiObjectCached({
-  //   schema,
-  //   prompt,
-  //   model: openai("o3"),
-  // })
 
   const outDir = path.join(process.cwd(), "changelogs")
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir)


### PR DESCRIPTION
## Fix changelog to properly link to related PRs

/Fixes #236
/claim #236
### Changes:
- Add post-processing step to convert # 123 references to [# 123](url) markdown links
- Build PR map from analysis files to lookup PR URLs
- Handle PR number collisions across multiple repositories (store arrays instead of single values)
- Add demo script to showcase the fix without requiring OpenAI API key

### How it works:
1. Parse all PR analysis JSON files and build a lookup map
2. AI generates the changelog with plain #123 references
3. Regex post-processing converts all # 123 → [# 123](url) with actual GitHub URLs

### Testing:
Run `bun run generate:changelog` to see the fix in action using real October 2025 data.

https://github.com/user-attachments/assets/58ccadf4-1215-40e3-a56d-dbeb2be4ad7a

/claim #236
<img width="1005" height="269" alt="image" src="https://github.com/user-attachments/assets/b191ca01-97e9-4cce-99d4-f798492a94eb" />
<img width="1006" height="651" alt="image" src="https://github.com/user-attachments/assets/40e9b5b0-9261-4af5-91bc-2ae89db39178" />
<img width="1020" height="476" alt="image" src="https://github.com/user-attachments/assets/c47e40e4-ae15-4ccf-be9b-75407413fef5" />
