### PR TITLE
docs: update star counting format in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The sponsorship system calculates monthly payments based on your **weekly star c
 
 **Step 1: Collect Weekly Stars**
 - All complete weeks in the month are analyzed
-- Each week's star string is converted to a numeric count (1 ⭐ = 1 star, ⭐⭐⭐ = 3 stars)
+- Each week's star string is converted to a numeric count (⭐ = 1 star, ⭐⭐⭐ = 3 stars)
 - Example: `[2, 2, 2, 1, 0]` means 2 stars in week 1, 2 stars in week 2, etc.
 
 **Step 2: Calculate Metrics**

--- a/lib/data-processing/generateMarkdown.ts
+++ b/lib/data-processing/generateMarkdown.ts
@@ -303,7 +303,7 @@ export async function generateMarkdown(
   markdown += "**Step 1: Collect Weekly Stars**\n"
   markdown += "- All complete weeks in the month are analyzed\n"
   markdown +=
-    "- Each week's star string is converted to a numeric count (1 ⭐ = 1 star, ⭐⭐⭐ = 3 stars)\n"
+    "- Each week's star string is converted to a numeric count (⭐ = 1 star, ⭐⭐⭐ = 3 stars)\n"
   markdown +=
     "- Example: `[2, 2, 2, 1, 0]` means 2 stars in week 1, 2 stars in week 2, etc.\n\n"
 

--- a/tests/__snapshots__/test-generate-markdown.test.ts.snap
+++ b/tests/__snapshots__/test-generate-markdown.test.ts.snap
@@ -82,7 +82,7 @@ The sponsorship system calculates monthly payments based on your **weekly star c
 
 **Step 1: Collect Weekly Stars**
 - All complete weeks in the month are analyzed
-- Each week's star string is converted to a numeric count (1 ⭐ = 1 star, ⭐⭐⭐ = 3 stars)
+- Each week's star string is converted to a numeric count (⭐ = 1 star, ⭐⭐⭐ = 3 stars)
 - Example: \`[2, 2, 2, 1, 0]\` means 2 stars in week 1, 2 stars in week 2, etc.
 
 **Step 2: Calculate Metrics**


### PR DESCRIPTION
Change star counting format from '(1  = 1 star,  👑= 3 stars)' to '( = 1 star,  ⭐⭐⭐= 3 stars)' for better clarity and simplified representation