### PR TITLE
remove unnecessary console logs & add key uniqueness

### DIFF
--- a/frontend/src/components/PrAttributeBadges.tsx
+++ b/frontend/src/components/PrAttributeBadges.tsx
@@ -29,7 +29,6 @@ function stringToHSL(str: string): string {
 
 export function PrAttributeBadges({ pr }: PrAttributeBadgesProps) {
   const [isExpanded, setIsExpanded] = useState(false)
-  console.log(pr)
 
   // Get active attributes
   const activeAttributes = Object.entries(pr)

--- a/frontend/src/components/PrsTable.tsx
+++ b/frontend/src/components/PrsTable.tsx
@@ -41,7 +41,7 @@ export function PrsTable({ prs, inModal = false, name }: PRsByRepositoryProps) {
 
   const renderMobileCard = (pr: PrAnalysisResult) => (
     <div
-      key={pr.number}
+      key={`${pr.repo}-${pr.number}`}
       className="bg-white border border-gray-200 rounded-lg p-4 mb-3"
     >
       <div className="flex items-start justify-between mb-2">
@@ -114,7 +114,7 @@ export function PrsTable({ prs, inModal = false, name }: PRsByRepositoryProps) {
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {prsToRender.map((pr) => (
-              <tr key={pr.number} className="hover:bg-gray-50">
+              <tr key={`${pr.repo}-${pr.number}`} className="hover:bg-gray-50">
                 <td className="px-3 py-2 whitespace-nowrap text-sm">
                   <a
                     href={pr.url}


### PR DESCRIPTION
Refactor PR attribute rendering and improve key uniqueness

- Removed console log from PrAttributeBadges component.
- Updated key generation for mobile card and table rows in PrsTable component to include repository name for better uniqueness.

- Before 

<img width="1920" height="1020" alt="Screenshot 2025-11-08 233117" src="https://github.com/user-attachments/assets/37890230-c6db-4efb-8096-317ef170d798" />

- After: 


<img width="1920" height="1080" alt="Screenshot 2025-11-08 233440" src="https://github.com/user-attachments/assets/18ebd521-c4cd-4f49-be45-0fcf82d60d09" />

