### PR TITLE
Remove code owner review weighting, non-maintainers can get 1 point max for reviewing

### DIFF
--- a/lib/scoring/getContributorScore.ts
+++ b/lib/scoring/getContributorScore.ts
@@ -91,19 +91,16 @@ export function getContributorScore({
   const isMaintainer =
     contributor && (MAINTAINERS as Record<string, string>)[contributor]
 
-  const distinctPrsReviewedNonCodeOwner =
-    contributorStats.distinctPrsReviewedNonCodeOwner || 0
-  result.score += Math.min(
-    distinctPrsReviewedNonCodeOwner,
-    isMaintainer ? 15 : 5,
-  )
+  const totalDistinctPrsReviewed =
+    (contributorStats.distinctPrsReviewedNonCodeOwner || 0) +
+    (contributorStats.distinctPrsReviewedAsCodeOwner || 0)
+  let reviewPoints = Math.min(totalDistinctPrsReviewed, isMaintainer ? 15 : 5)
 
-  const distinctPrsReviewedAsCodeOwner =
-    contributorStats.distinctPrsReviewedAsCodeOwner || 0
-  result.score += Math.min(
-    distinctPrsReviewedAsCodeOwner,
-    isMaintainer ? 30 : 10,
-  )
+  if (!isMaintainer) {
+    reviewPoints = Math.min(reviewPoints, impactWorth.Tiny)
+  }
+
+  result.score += reviewPoints
 
   return result
 }

--- a/tests/test-pr-scoring.test.ts
+++ b/tests/test-pr-scoring.test.ts
@@ -24,7 +24,7 @@ it("should count distinct PRs reviewed", () => {
     contributorStats: stats,
     contributor: "test-user",
   })
-  expect(result.score).toBe(2) // Should get 2 points for reviewing 2 distinct PRs
+  expect(result.score).toBe(1) // Should be capped at 1 point for non-maintainers
 })
 
 it("should cap review points at 10", () => {
@@ -48,7 +48,7 @@ it("should cap review points at 10", () => {
     contributorStats: stats,
     contributor: "test-user",
   })
-  expect(result.score).toBe(5) // Should be capped at 5 points
+  expect(result.score).toBe(1) // Should be capped at 1 point for non-maintainers
 })
 
 it("should handle edge cases", () => {
@@ -96,7 +96,7 @@ it("should correctly calculate score from distinct PRs reviewed", () => {
     contributorStats: stats,
     contributor: "test-user",
   })
-  expect(result.score).toBe(5) // Should get 5 points for reviewing 5 distinct PRs
+  expect(result.score).toBe(1) // Should be capped at 1 point for non-maintainers
 })
 
 // Additional tests to verify the distinct PRs reviewed functionality
@@ -146,7 +146,7 @@ describe("distinct PRs reviewed functionality", () => {
       contributorStats,
       contributor: "test-user",
     })
-    expect(result.score).toBe(5) // Should be capped at 5 points
+    expect(result.score).toBe(1) // Should be capped at 1 point for non-maintainers
   })
 
   it("should handle edge case of no reviews", () => {
@@ -194,74 +194,7 @@ describe("distinct PRs reviewed functionality", () => {
       contributorStats,
       contributor: "test-user",
     })
-    expect(result.score).toBe(5) // Should get 5 points for 5 distinct PRs reviewed
-  })
-
-  it("should count distinct PRs reviewed as code owner", () => {
-    const mockPRs: AnalyzedPR[] = []
-    const statsAsCodeOwner: ContributorStats = {
-      reviewsReceived: 0,
-      rejectionsReceived: 0,
-      approvalsReceived: 0,
-      approvalsGiven: 0,
-      rejectionsGiven: 0,
-      prsOpened: 0,
-      prsMerged: 0,
-      issuesCreated: 0,
-      bountiedIssuesCount: 0,
-      bountiedIssuesTotal: 0,
-      distinctPrsReviewedAsCodeOwner: 29,
-    }
-
-    const scoreAsCodeOwner = getContributorScore({
-      contributorPRs: mockPRs,
-      contributorStats: statsAsCodeOwner,
-      contributor: "test-user",
-    })
-    expect(scoreAsCodeOwner.score).toBe(10)
-
-    const statsNonCodeOwner: ContributorStats = {
-      reviewsReceived: 0,
-      rejectionsReceived: 0,
-      approvalsReceived: 0,
-      approvalsGiven: 0,
-      rejectionsGiven: 0,
-      prsOpened: 0,
-      prsMerged: 0,
-      issuesCreated: 0,
-      bountiedIssuesCount: 0,
-      bountiedIssuesTotal: 0,
-      distinctPrsReviewedNonCodeOwner: 29,
-    }
-
-    const scoreNonCodeOwner = getContributorScore({
-      contributorPRs: mockPRs,
-      contributorStats: statsNonCodeOwner,
-      contributor: "test-user",
-    })
-    expect(scoreNonCodeOwner.score).toBe(5)
-
-    const statsMixed: ContributorStats = {
-      reviewsReceived: 0,
-      rejectionsReceived: 0,
-      approvalsReceived: 0,
-      approvalsGiven: 0,
-      rejectionsGiven: 0,
-      prsOpened: 0,
-      prsMerged: 0,
-      issuesCreated: 0,
-      bountiedIssuesCount: 0,
-      bountiedIssuesTotal: 0,
-      distinctPrsReviewedNonCodeOwner: 15,
-      distinctPrsReviewedAsCodeOwner: 15,
-    }
-
-    const scoreMixed = getContributorScore({
-      contributorPRs: mockPRs,
-      contributorStats: statsMixed,
-      contributor: "test-user",
-    })
-    expect(scoreMixed.score).toBe(15)
+    expect(result.score).toBe(1) // Should be capped at 1 point for non-maintainers
   })
 })
 
@@ -291,7 +224,7 @@ describe("maintainer scoring", () => {
         contributorStats: stats,
         contributor: maintainerUsername,
       })
-      expect(result.score).toBe(17)
+      expect(result.score).toBe(15)
 
       const nonMaintainerUsername = "test-user"
       const nonMaintainerResult = getContributorScore({
@@ -299,8 +232,8 @@ describe("maintainer scoring", () => {
         contributorStats: stats,
         contributor: nonMaintainerUsername,
       })
-      // Capped at 5 for non-code-owner, and 10 for code-owner
-      expect(nonMaintainerResult.score).toBe(7)
+      // Non-maintainers can only earn up to one tiny contribution worth of review points
+      expect(nonMaintainerResult.score).toBe(1)
     },
   )
 })


### PR DESCRIPTION
## Summary
- remove code owner-specific review scoring and use a single review cap
- update review scoring tests to reflect the unified review handling

## Testing
- bun test tests/test-pr-scoring.test.ts
- bunx tsc --noEmit
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924a1e775c4832e93145a6debc7ee29)