### PR TITLE
Remove outdated section headers from the current week overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,6 @@ You can find AI-generated monthly changelogs in the [changelogs directory](./cha
 
 > Want to run locally? See the [Development Section](#development)
 
-The current week is shown below. There are 4 major sections:
-
-- [Contributor Overview](#contributor-overview)
-- [PRs by Repository](#prs-by-repository)
-- [PRs by Contributor](#changes-by-contributor)
-- [Scoring & Sponsorship System](#scoring--sponsorship-system)
-
 ## Current Week
 
 <!-- START_CURRENT_WEEK -->


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by removing the description of the four major sections previously listed under the "Current Week" heading. This change streamlines the documentation and removes redundant information.