### PR TITLE
Shift weekly start date to Tuesday 18:30 UTC

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,24 +1,24 @@
 import * as fs from "fs"
-import type { AnalyzedPR, ContributorStats } from "lib/types"
-import { getRepos } from "lib/data-retrieval/getRepos"
+import { analyzePRWithAI } from "lib/ai-stuff/analyze-pr"
+import { getLastWednesday } from "lib/ai/date-utils"
 import {
   generateMarkdown,
   scoreToStarString,
 } from "lib/data-processing/generateMarkdown"
-import { getMergedPRs } from "lib/data-retrieval/getMergedPRs"
+import {
+  getExistingPrAnalysis,
+  loadPrAnalysis,
+  storePrAnalysis,
+} from "lib/data-processing/storePrAnalysis"
 import { getAllPRs } from "lib/data-retrieval/getAllPRs"
 import { getBountiedIssues } from "lib/data-retrieval/getBountiedIssues"
 import { getIssuesCreated } from "lib/data-retrieval/getIssuesCreated"
-import { getLastWednesday } from "lib/ai/date-utils"
-import { analyzePRWithAI } from "lib/ai-stuff/analyze-pr"
+import { getMergedPRs } from "lib/data-retrieval/getMergedPRs"
+import { getRepos } from "lib/data-retrieval/getRepos"
 import { processDiscussionsForContributors } from "lib/data-retrieval/processDiscussions"
-import {
-  storePrAnalysis,
-  loadPrAnalysis,
-  getExistingPrAnalysis,
-} from "lib/data-processing/storePrAnalysis"
-import { fetchCodeownersFile } from "lib/utils/code-owner-utils"
 import { postMergeComment } from "lib/notifications/notify-pr-change"
+import type { AnalyzedPR, ContributorStats } from "lib/types"
+import { fetchCodeownersFile } from "lib/utils/code-owner-utils"
 
 export async function generateOverview(startDate: string) {
   const startDateString = startDate
@@ -404,6 +404,9 @@ async function generateAndWriteFiles(
 
 export async function generateWeeklyOverview() {
   const weekStart = getLastWednesday(new Date())
-  const weekStartString = weekStart.toISOString().split("T")[0]
+  const weekStartOffset = new Date(
+    weekStart.getTime() - 5.5 * 60 * 60 * 1000, // 5.5 hours
+  )
+  const weekStartString = weekStartOffset.toISOString().split("T")[0] // 6:30 pm UTC Tuesday
   await generateOverview(weekStartString)
 }

--- a/lib/ai/date-utils.ts
+++ b/lib/ai/date-utils.ts
@@ -1,16 +1,9 @@
 export function getLastWednesday(date: Date): Date {
   const result = new Date(date)
-  result.setUTCHours(0, 0, 0, 0) // Normalize to midnight UTC
-
-  // Get days to subtract (0 = Sunday, 3 = Wednesday)
   const currentDay = result.getUTCDay()
-  const daysToSubtract =
-    currentDay < 3
-      ? // If before Wednesday
-        currentDay + 4
-      : // Add days to get to previous Wednesday
-        currentDay - 3 // Subtract days to get to previous/current Wednesday
+  const daysToSubtract = (currentDay + 4) % 7
 
   result.setUTCDate(result.getUTCDate() - daysToSubtract)
+  result.setUTCHours(0, 0, 0, 0)
   return result
 }

--- a/tests/test-date-calc.test.ts
+++ b/tests/test-date-calc.test.ts
@@ -61,3 +61,10 @@ test("normalizes to midnight", () => {
   expect(result.getUTCSeconds()).toBe(0)
   expect(result.getUTCMilliseconds()).toBe(0)
 })
+
+test("returns previous Wednesday when early Wednesday in UTC", () => {
+  const earlyWednesday = new Date("2024-01-17T00:30:00.000Z")
+  expect(getLastWednesday(earlyWednesday).toISOString().split("T")[0]).toBe(
+    "2024-01-17",
+  )
+})


### PR DESCRIPTION
Summary
- Derive weekly start from last Wednesday with a 5.5-hour offset to align with Tuesday 18:30 UTC
- Keep last-Wednesday calculation consistent in UTC and document the offset
- Add a test covering early-Wednesday UTC behavior