### PR TITLE
feat: add review timing overview

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,11 @@ import { getRepos } from "lib/data-retrieval/getRepos"
 import { processDiscussionsForContributors } from "lib/data-retrieval/processDiscussions"
 import { postMergeComment } from "lib/notifications/notify-pr-change"
 import { SENIOR_STAFF_USERNAMES } from "lib/constants"
-import type { AnalyzedPR, ContributorStats } from "lib/types"
+import type {
+  AnalyzedPR,
+  ContributorStats,
+  ReviewLatencyEntry,
+} from "lib/types"
 import { fetchCodeownersFile } from "lib/utils/code-owner-utils"
 
 export async function generateOverview(
@@ -31,6 +35,7 @@ export async function generateOverview(
 
   const repos = await getRepos()
   const mergedPrsWithAnalysis: AnalyzedPR[] = []
+  const reviewLatencyEntries: ReviewLatencyEntry[] = []
   const contributorData: Record<string, ContributorStats> = {}
   const reviewerToReviewedPrs: Record<
     string,
@@ -106,6 +111,20 @@ export async function generateOverview(
       contributorData[contributor].rejectionsReceived += pr.rejectionsReceived
       contributorData[contributor].approvalsReceived += pr.approvalsReceived
       contributorData[contributor].prsOpened += 1
+
+      if (pr.firstReviewAt && pr.timeToFirstReviewMs !== undefined) {
+        reviewLatencyEntries.push({
+          repo,
+          number: pr.number,
+          title: pr.title,
+          url: pr.html_url,
+          author: contributor,
+          createdAt: pr.created_at,
+          firstReviewAt: pr.firstReviewAt,
+          firstReviewer: pr.firstReviewer ?? "",
+          timeToFirstReviewMs: pr.timeToFirstReviewMs,
+        })
+      }
 
       const seniorStaffReviewStats = Object.entries(
         pr.allReviewsByUser ?? {},
@@ -387,6 +406,7 @@ export async function generateOverview(
     contributorData,
     startDateString,
     repoOwnersMap,
+    reviewLatencyEntries,
   )
 }
 
@@ -395,6 +415,7 @@ async function generateAndWriteFiles(
   contributorData: Record<string, ContributorStats>,
   startDateString: string,
   repoOwnersMap: Record<string, string[]>,
+  reviewLatencyEntries: ReviewLatencyEntry[],
 ) {
   console.log("Generating markdown")
   // Group PRs by contributor
@@ -424,6 +445,7 @@ async function generateAndWriteFiles(
     contributorData,
     startDateString,
     repoOwnersMap,
+    reviewLatencyEntries,
   )
   console.log("Generated markdown", markdown)
 

--- a/lib/data-processing/generateMarkdown.ts
+++ b/lib/data-processing/generateMarkdown.ts
@@ -1,7 +1,28 @@
-import type { AnalyzedPR, ContributorStats } from "lib/types"
+import type {
+  AnalyzedPR,
+  ContributorStats,
+  ReviewLatencyEntry,
+} from "lib/types"
 import { getContributorScore } from "../scoring"
 import { scoreToStarString } from "../scoring/scoreToStars"
 export { scoreToStarString }
+
+export function formatReviewLatency(ms: number): string {
+  const totalMinutes = Math.max(0, Math.round(ms / 60_000))
+  const days = Math.floor(totalMinutes / (24 * 60))
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60)
+  const minutes = totalMinutes % 60
+  const parts: string[] = []
+
+  if (days > 0) parts.push(`${days}d`)
+  if (hours > 0) parts.push(`${hours}h`)
+  if (minutes > 0 || parts.length === 0) parts.push(`${minutes}m`)
+
+  return parts.join(" ")
+}
+
+const escapeMarkdownTableCell = (value: string): string =>
+  value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ")
 
 export const impactIcon = (impact: "Major" | "Minor" | "Tiny") => {
   switch (impact) {
@@ -82,6 +103,7 @@ export async function generateMarkdown(
   contributorIdToStatsMap: Record<string, ContributorStats>,
   weekStart: string,
   repoOwnersMap: Record<string, string[]> = {},
+  reviewLatencyEntries: ReviewLatencyEntry[] = [],
 ): Promise<string> {
   const tinyPrUrls = new Set(
     prs.filter((pr) => pr.impact === "Tiny").map((pr) => pr.url),
@@ -106,10 +128,11 @@ export async function generateMarkdown(
 
   const scoringDocPath = "/docs/sponsorship-calculation-explanation.md"
   let markdown = `# Contribution Overview ${weekStart}\n\n`
-  markdown += "The current week is shown below. There are 3 major sections:\n\n"
+  markdown += "The current week is shown below. There are several sections:\n\n"
   markdown += "- [Contributor Overview](#contributor-overview)\n"
   markdown += "- [PRs by Repository](#prs-by-repository)\n"
   markdown += "- [PRs by Contributor](#changes-by-contributor)\n"
+  markdown += "- [Review Timing](#review-timing)\n"
   markdown += `- [Scoring & Sponsorship Details](${scoringDocPath})\n\n`
 
   // Remove bot accounts from contributor data
@@ -313,6 +336,28 @@ export async function generateMarkdown(
     },
   )
   markdown += "\n"
+
+  if (reviewLatencyEntries.length > 0) {
+    markdown += "## Review Timing\n\n"
+    markdown +=
+      "| PR | Repository | Author | First Reviewer | First Review | Time to First Review |\n"
+    markdown +=
+      "|----|------------|--------|----------------|--------------|----------------------|\n"
+
+    reviewLatencyEntries
+      .slice()
+      .sort((a, b) => b.timeToFirstReviewMs - a.timeToFirstReviewMs)
+      .forEach((entry) => {
+        markdown += `| [#${entry.number} ${escapeMarkdownTableCell(
+          entry.title,
+        )}](${entry.url}) | ${entry.repo} | ${entry.author} | ${
+          entry.firstReviewer
+        } | ${entry.firstReviewAt} | ${formatReviewLatency(
+          entry.timeToFirstReviewMs,
+        )} |\n`
+      })
+    markdown += "\n"
+  }
 
   // Generate changes by repository
   markdown += "## Changes by Repository\n\n"

--- a/lib/data-retrieval/getAllPRs.ts
+++ b/lib/data-retrieval/getAllPRs.ts
@@ -114,6 +114,13 @@ export async function getAllPRs(
       const rejectionsReceived = processedReviews.filter(
         (review) => review.state === "CHANGES_REQUESTED",
       ).length
+      const firstReview = reviews
+        .filter((review) => review.submitted_at)
+        .sort(
+          (a, b) =>
+            new Date(a.submitted_at).getTime() -
+            new Date(b.submitted_at).getTime(),
+        )[0]
 
       const reviewsByUser = processedReviews.reduce<
         Record<string, ReviewerStats>
@@ -150,6 +157,15 @@ export async function getAllPRs(
         reviewsReceived: processedReviews.length,
         approvalsReceived,
         rejectionsReceived,
+        firstReviewAt: firstReview?.submitted_at,
+        firstReviewer: firstReview?.user.login,
+        timeToFirstReviewMs: firstReview
+          ? Math.max(
+              0,
+              new Date(firstReview.submitted_at).getTime() -
+                new Date(pr.created_at).getTime(),
+            )
+          : undefined,
         reviewsByUser,
         allReviewsByUser,
         isClosed: pr.state === "closed",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,6 +28,18 @@ export interface DiscussionContribution {
   count: number
 }
 
+export interface ReviewLatencyEntry {
+  repo: string
+  number: number
+  title: string
+  url: string
+  author: string
+  createdAt: string
+  firstReviewAt: string
+  firstReviewer: string
+  timeToFirstReviewMs: number
+}
+
 export interface ContributorStats {
   reviewsReceived: number
   rejectionsReceived: number
@@ -91,6 +103,9 @@ export interface PullRequestWithReviews extends PullRequest {
   rejectionsReceived: number
   approvalsReceived: number
   isClosed: boolean
+  firstReviewAt?: string
+  firstReviewer?: string
+  timeToFirstReviewMs?: number
   reviewsByUser?: Record<string, ReviewerStats>
   allReviewsByUser?: Record<string, ReviewerStats>
 }

--- a/tests/__snapshots__/test-generate-markdown.test.ts.snap
+++ b/tests/__snapshots__/test-generate-markdown.test.ts.snap
@@ -3,11 +3,12 @@
 exports[`generateMarkdown should generate markdown with expected sections and contributor data: markdown 1`] = `
 "# Contribution Overview 2024-07-01
 
-The current week is shown below. There are 3 major sections:
+The current week is shown below. There are several sections:
 
 - [Contributor Overview](#contributor-overview)
 - [PRs by Repository](#prs-by-repository)
 - [PRs by Contributor](#changes-by-contributor)
+- [Review Timing](#review-timing)
 - [Scoring & Sponsorship Details](/docs/sponsorship-calculation-explanation.md)
 
 ## PRs by Repository
@@ -66,6 +67,13 @@ pie
 |---|---|---|---|---|---|---|---|---|
 | [alice](#alice) | 1 | 1 | 0 | 2 | 0 | 2 | 1 | 1 |
 | [bob](#bob) | 0 | 0 | 0 | 1 | 0 | 1 | 0 | 0 |
+
+## Review Timing
+
+| PR | Repository | Author | First Reviewer | First Review | Time to First Review |
+|----|------------|--------|----------------|--------------|----------------------|
+| [#1 Add feature X](https://github.com/org/repo/pull/1) | org/repo | alice | reviewer-a | 2024-06-02T02:30:00Z | 1d 2h 30m |
+| [#2 Fix bug Y](https://github.com/org/repo/pull/2) | org/repo | bob | reviewer-b | 2024-06-03T01:15:00Z | 1h 15m |
 
 ## Changes by Repository
 

--- a/tests/test-generate-markdown.test.ts
+++ b/tests/test-generate-markdown.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "bun:test"
-import { generateMarkdown } from "lib/data-processing/generateMarkdown"
-import type { AnalyzedPR, ContributorStats } from "lib/types"
+import {
+  formatReviewLatency,
+  generateMarkdown,
+} from "lib/data-processing/generateMarkdown"
+import type {
+  AnalyzedPR,
+  ContributorStats,
+  ReviewLatencyEntry,
+} from "lib/types"
 
 const minimalPrAttributes = {
   mostly_style: false,
@@ -175,13 +182,50 @@ const mockStats: Record<string, ContributorStats> = {
   },
 }
 
+const mockReviewLatencyEntries: ReviewLatencyEntry[] = [
+  {
+    repo: "org/repo",
+    number: 1,
+    title: "Add feature X",
+    url: "https://github.com/org/repo/pull/1",
+    author: "alice",
+    createdAt: "2024-06-01T00:00:00Z",
+    firstReviewAt: "2024-06-02T02:30:00Z",
+    firstReviewer: "reviewer-a",
+    timeToFirstReviewMs: 26.5 * 60 * 60 * 1000,
+  },
+  {
+    repo: "org/repo",
+    number: 2,
+    title: "Fix bug Y",
+    url: "https://github.com/org/repo/pull/2",
+    author: "bob",
+    createdAt: "2024-06-03T00:00:00Z",
+    firstReviewAt: "2024-06-03T01:15:00Z",
+    firstReviewer: "reviewer-b",
+    timeToFirstReviewMs: 75 * 60 * 1000,
+  },
+]
+
 describe("generateMarkdown", () => {
+  it("formats review latency durations", () => {
+    expect(formatReviewLatency(0)).toBe("0m")
+    expect(formatReviewLatency(75 * 60 * 1000)).toBe("1h 15m")
+    expect(formatReviewLatency(26.5 * 60 * 60 * 1000)).toBe("1d 2h 30m")
+  })
+
   it("should generate markdown with expected sections and contributor data", async () => {
-    const markdown = await generateMarkdown(mockPRs, mockStats, "2024-07-01", {
-      "tscircuit/gyromug": ["alice", "bob"],
-      "tscircuit/schematic-corpus": ["Abse2001", "alice"],
-      "tscircuit/lol": [],
-    })
+    const markdown = await generateMarkdown(
+      mockPRs,
+      mockStats,
+      "2024-07-01",
+      {
+        "tscircuit/gyromug": ["alice", "bob"],
+        "tscircuit/schematic-corpus": ["Abse2001", "alice"],
+        "tscircuit/lol": [],
+      },
+      mockReviewLatencyEntries,
+    )
     expect(markdown).toContain("# Contribution Overview 2024-07-01")
     expect(markdown).toContain("## Contributor Overview")
     expect(markdown).toContain("alice")
@@ -193,6 +237,13 @@ describe("generateMarkdown", () => {
     expect(markdown).toContain("Update docs")
     expect(markdown).toContain("Discussion Contribution Legend")
     expect(markdown).toContain("## Staff Pass Ratio (SPR)")
+    expect(markdown).toContain("## Review Timing")
+    expect(markdown).toContain("| [#1 Add feature X]")
+    expect(markdown.indexOf("#1 Add feature X")).toBeLessThan(
+      markdown.indexOf("#2 Fix bug Y"),
+    )
+    expect(markdown).toContain("1d 2h 30m")
+    expect(markdown).toContain("1h 15m")
     expect(markdown).toContain("| [alice](#alice) | 1 | 1 | 2 | 0.0% |")
     expect(markdown).toContain("| [bob](#bob) | 1 | 2 | 1 | -100.0% |")
     expect(markdown).toContain("<summary>alice SPR PRs (1)</summary>")


### PR DESCRIPTION
Fixes #284

@algora-pbc /claim #284

Summary
- Add first-review timing metadata while fetching PR reviews.
- Carry reviewed PR timing entries into the weekly overview generation pipeline.
- Render a Review Timing table for every PR that received a review, sorted by slowest time to first review.

Verification
- bun test
- bun x tsc --noEmit
- bun run format:check
- bun run build
- git diff --check