### PR TITLE
 Align contribution overview windows to 18:00 UTC cutoffs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs"
 import { analyzePRWithAI } from "lib/ai-stuff/analyze-pr"
-import { getLastTuesday1830 } from "lib/ai/date-utils"
+import { getContributionOverviewWindow } from "lib/ai/date-utils"
 import {
   generateMarkdown,
   scoreToStarString,
@@ -457,7 +457,7 @@ async function generateAndWriteFiles(
 }
 
 export async function generateWeeklyOverview() {
-  const weekStart = getLastTuesday1830(new Date())
-  const weekStartString = weekStart.toISOString()
-  await generateOverview(weekStartString)
+  const { startDate, endDate } = getContributionOverviewWindow(new Date())
+  const weekStartString = startDate.toISOString()
+  await generateOverview(weekStartString, endDate)
 }

--- a/lib/ai/date-utils.ts
+++ b/lib/ai/date-utils.ts
@@ -15,31 +15,36 @@ export function getLastWednesday(date: Date): Date {
   return result
 }
 
-/**
- * Gets the most recent Tuesday at 18:30 UTC.
- * If the current time is before Tuesday 18:30 UTC, returns the previous Tuesday at 18:30 UTC.
- * If the current time is on or after Tuesday 18:30 UTC, returns the current Tuesday at 18:30 UTC.
- */
-export function getLastTuesday1830(date: Date): Date {
+export const CONTRIBUTION_OVERVIEW_CUTOFF_HOUR_UTC = 18
+
+function setContributionOverviewCutoff(date: Date): Date {
   const result = new Date(date)
+  result.setUTCHours(CONTRIBUTION_OVERVIEW_CUTOFF_HOUR_UTC, 0, 0, 0)
+  return result
+}
+
+export function getLatestContributionOverviewCutoff(date: Date): Date {
+  const cutoff = setContributionOverviewCutoff(date)
+  if (date.getTime() < cutoff.getTime()) {
+    cutoff.setUTCDate(cutoff.getUTCDate() - 1)
+  }
+  return cutoff
+}
+
+export function getContributionOverviewWindow(date: Date): {
+  startDate: Date
+  endDate: Date
+} {
+  const endDate = getLatestContributionOverviewCutoff(date)
+  const startDate = new Date(endDate)
 
   // Get the current day (0 = Sunday, 2 = Tuesday)
-  const currentDay = result.getUTCDay()
+  const currentDay = startDate.getUTCDay()
 
-  // Calculate days to subtract to get to the most recent Tuesday
-  // If it's Tuesday, check if we're past 18:30 UTC
+  // Tuesday at cutoff closes the previous reporting week.
   let daysToSubtract: number
   if (currentDay === 2) {
-    // It's Tuesday - check if we're past 18:30 UTC
-    const currentHour = result.getUTCHours()
-    const currentMinute = result.getUTCMinutes()
-    if (currentHour > 18 || (currentHour === 18 && currentMinute >= 30)) {
-      // We're past 18:30 UTC on Tuesday, use today
-      daysToSubtract = 0
-    } else {
-      // We're before 18:30 UTC on Tuesday, go back to last Tuesday
-      daysToSubtract = 7
-    }
+    daysToSubtract = 7
   } else if (currentDay < 2) {
     // Sunday (0) or Monday (1) - go back to previous Tuesday
     daysToSubtract = currentDay + 5 // Sunday: 0+5=5, Monday: 1+5=6
@@ -48,8 +53,12 @@ export function getLastTuesday1830(date: Date): Date {
     daysToSubtract = currentDay - 2
   }
 
-  result.setUTCDate(result.getUTCDate() - daysToSubtract)
-  result.setUTCHours(18, 30, 0, 0) // Set to 18:30 UTC
+  startDate.setUTCDate(startDate.getUTCDate() - daysToSubtract)
+  startDate.setUTCHours(CONTRIBUTION_OVERVIEW_CUTOFF_HOUR_UTC, 0, 0, 0)
 
-  return result
+  return { startDate, endDate }
+}
+
+export function getLastTuesday1800(date: Date): Date {
+  return getContributionOverviewWindow(date).startDate
 }

--- a/scripts/generate-overview-for-date.ts
+++ b/scripts/generate-overview-for-date.ts
@@ -1,5 +1,5 @@
 import { generateOverview } from ".."
-import { getLastTuesday1830 } from "../lib/ai/date-utils"
+import { getContributionOverviewWindow } from "../lib/ai/date-utils"
 
 const dateArg = process.argv[2]
 
@@ -28,14 +28,14 @@ if (isNaN(parsedDate.getTime())) {
 const currentTime = new Date(dateArg)
 currentTime.setUTCHours(18, 0, 0, 0)
 
-// Calculate the start date (last Tuesday at 18:30 UTC based on the current time)
-const weekStart = getLastTuesday1830(currentTime)
-const weekStartString = weekStart.toISOString()
+const { startDate, endDate } = getContributionOverviewWindow(currentTime)
+const weekStartString = startDate.toISOString()
 
 console.log(`Current time: ${currentTime.toISOString()}`)
-console.log(`Week start (last Tuesday): ${weekStart.toISOString()}`)
+console.log(`Week start: ${startDate.toISOString()}`)
+console.log(`Week end: ${endDate.toISOString()}`)
 console.log(
-  `Generating overview from ${weekStartString} to ${currentTime.toISOString()}`,
+  `Generating overview from ${weekStartString} to ${endDate.toISOString()}`,
 )
 
-generateOverview(weekStartString, currentTime).catch(console.error)
+generateOverview(weekStartString, endDate).catch(console.error)

--- a/tests/test-date-calc.test.ts
+++ b/tests/test-date-calc.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test"
-import { getLastTuesday1830, getLastWednesday } from "../lib/ai/date-utils"
+import {
+  getContributionOverviewWindow,
+  getLastTuesday1800,
+  getLastWednesday,
+  getLatestContributionOverviewCutoff,
+} from "../lib/ai/date-utils"
 
 test("returns same date when current day is Wednesday", () => {
   const wednesday = new Date("2024-01-17") // A Wednesday
@@ -62,77 +67,76 @@ test("normalizes to midnight", () => {
   expect(result.getUTCMilliseconds()).toBe(0)
 })
 
-// Tests for getLastTuesday1830
+// Tests for contribution overview windows
 
-test("getLastTuesday1830: returns same Tuesday when past 18:30 UTC", () => {
-  const tuesdayAfter1830 = new Date("2024-01-16T19:00:00.000Z") // Tuesday 19:00 UTC
-  const result = getLastTuesday1830(tuesdayAfter1830)
-  expect(result.toISOString()).toBe("2024-01-16T18:30:00.000Z")
+// Given Wednesday Jan 17 at 19:00 UTC, the run is after that day's 18:00 UTC
+// cutoff, so the latest reporting cutoff should be Wednesday Jan 17 at 18:00 UTC.
+test("getLatestContributionOverviewCutoff: returns today's 18:00 UTC after cutoff", () => {
+  const afterCutoff = new Date("2024-01-17T19:00:00.000Z")
+  const result = getLatestContributionOverviewCutoff(afterCutoff)
+  expect(result.toISOString()).toBe("2024-01-17T18:00:00.000Z")
 })
 
-test("getLastTuesday1830: returns previous Tuesday when before 18:30 UTC on Tuesday", () => {
-  const tuesdayBefore1830 = new Date("2024-01-16T17:00:00.000Z") // Tuesday 17:00 UTC
-  const result = getLastTuesday1830(tuesdayBefore1830)
-  expect(result.toISOString()).toBe("2024-01-09T18:30:00.000Z")
+// Given Wednesday Jan 17 at 17:00 UTC, the run is before that day's 18:00 UTC
+// cutoff, so the latest reporting cutoff should be Tuesday Jan 16 at 18:00 UTC.
+test("getLatestContributionOverviewCutoff: returns yesterday's 18:00 UTC before cutoff", () => {
+  const beforeCutoff = new Date("2024-01-17T17:00:00.000Z")
+  const result = getLatestContributionOverviewCutoff(beforeCutoff)
+  expect(result.toISOString()).toBe("2024-01-16T18:00:00.000Z")
 })
 
-test("getLastTuesday1830: returns current week Tuesday when after Tuesday", () => {
-  const wednesday = new Date("2024-01-17T12:00:00.000Z") // Wednesday
-  const thursday = new Date("2024-01-18T12:00:00.000Z") // Thursday
-  const friday = new Date("2024-01-19T12:00:00.000Z") // Friday
-  const saturday = new Date("2024-01-20T12:00:00.000Z") // Saturday
-
-  expect(getLastTuesday1830(wednesday).toISOString()).toBe(
-    "2024-01-16T18:30:00.000Z",
-  )
-  expect(getLastTuesday1830(thursday).toISOString()).toBe(
-    "2024-01-16T18:30:00.000Z",
-  )
-  expect(getLastTuesday1830(friday).toISOString()).toBe(
-    "2024-01-16T18:30:00.000Z",
-  )
-  expect(getLastTuesday1830(saturday).toISOString()).toBe(
-    "2024-01-16T18:30:00.000Z",
-  )
+// Given Tuesday Jan 16 at 10:00 UTC, the Tuesday 18:00 UTC cutoff has not
+// happened yet. The report should cover Tuesday Jan 9 at 18:00 UTC through
+// Monday Jan 15 at 18:00 UTC.
+test("getContributionOverviewWindow: Tuesday morning runs through Monday cutoff", () => {
+  const tuesdayMorning = new Date("2024-01-16T10:00:00.000Z")
+  const result = getContributionOverviewWindow(tuesdayMorning)
+  expect(result.startDate.toISOString()).toBe("2024-01-09T18:00:00.000Z")
+  expect(result.endDate.toISOString()).toBe("2024-01-15T18:00:00.000Z")
 })
 
-test("getLastTuesday1830: returns previous Tuesday when before Tuesday", () => {
-  const sunday = new Date("2024-01-21T12:00:00.000Z") // Sunday
-  const monday = new Date("2024-01-22T12:00:00.000Z") // Monday
-
-  expect(getLastTuesday1830(sunday).toISOString()).toBe(
-    "2024-01-16T18:30:00.000Z",
-  )
-  expect(getLastTuesday1830(monday).toISOString()).toBe(
-    "2024-01-16T18:30:00.000Z",
-  )
+// Given Tuesday Jan 16 exactly at 18:00 UTC, the weekly cutoff has just happened.
+// The report should cover the completed week from Tuesday Jan 9 at 18:00 UTC
+// through Tuesday Jan 16 at 18:00 UTC.
+test("getContributionOverviewWindow: Tuesday at cutoff closes previous week", () => {
+  const tuesdayAtCutoff = new Date("2024-01-16T18:00:00.000Z")
+  const result = getContributionOverviewWindow(tuesdayAtCutoff)
+  expect(result.startDate.toISOString()).toBe("2024-01-09T18:00:00.000Z")
+  expect(result.endDate.toISOString()).toBe("2024-01-16T18:00:00.000Z")
 })
 
-test("getLastTuesday1830: handles month boundary correctly", () => {
-  const firstOfMonth = new Date("2024-02-01T12:00:00.000Z") // A Thursday
-  expect(getLastTuesday1830(firstOfMonth).toISOString()).toBe(
-    "2024-01-30T18:30:00.000Z",
-  )
+// Given Wednesday Jan 17 at 19:00 UTC, Tuesday's weekly cutoff has already
+// happened. The report should cover the new week from Tuesday Jan 16 at
+// 18:00 UTC through Wednesday Jan 17 at 18:00 UTC.
+test("getContributionOverviewWindow: Wednesday run starts from Tuesday cutoff", () => {
+  const wednesday = new Date("2024-01-17T19:00:00.000Z")
+  const result = getContributionOverviewWindow(wednesday)
+  expect(result.startDate.toISOString()).toBe("2024-01-16T18:00:00.000Z")
+  expect(result.endDate.toISOString()).toBe("2024-01-17T18:00:00.000Z")
 })
 
-test("getLastTuesday1830: handles year boundary correctly", () => {
-  const newYearsDay = new Date("2024-01-01T12:00:00.000Z") // A Monday
-  expect(getLastTuesday1830(newYearsDay).toISOString()).toBe(
-    "2023-12-26T18:30:00.000Z",
-  )
+// Given Thursday Feb 1 at 19:00 UTC, the report should cross the month boundary
+// cleanly: Tuesday Jan 30 at 18:00 UTC through Thursday Feb 1 at 18:00 UTC.
+test("getContributionOverviewWindow: handles month boundary correctly", () => {
+  const firstOfMonth = new Date("2024-02-01T19:00:00.000Z") // A Thursday
+  const result = getContributionOverviewWindow(firstOfMonth)
+  expect(result.startDate.toISOString()).toBe("2024-01-30T18:00:00.000Z")
+  expect(result.endDate.toISOString()).toBe("2024-02-01T18:00:00.000Z")
 })
 
-test("getLastTuesday1830: sets time to 18:30:00.000 UTC", () => {
-  const date = new Date("2024-01-17T15:30:45.123Z") // Wednesday with arbitrary time
-  const result = getLastTuesday1830(date)
-  expect(result.getUTCHours()).toBe(18)
-  expect(result.getUTCMinutes()).toBe(30)
-  expect(result.getUTCSeconds()).toBe(0)
-  expect(result.getUTCMilliseconds()).toBe(0)
+// Given Monday Jan 1 at 19:00 UTC, the report should cross the year boundary
+// cleanly: Tuesday Dec 26 at 18:00 UTC through Monday Jan 1 at 18:00 UTC.
+test("getContributionOverviewWindow: handles year boundary correctly", () => {
+  const newYearsDay = new Date("2024-01-01T19:00:00.000Z") // A Monday
+  const result = getContributionOverviewWindow(newYearsDay)
+  expect(result.startDate.toISOString()).toBe("2023-12-26T18:00:00.000Z")
+  expect(result.endDate.toISOString()).toBe("2024-01-01T18:00:00.000Z")
 })
 
-test("getLastTuesday1830: boundary case exactly at 18:30 UTC on Tuesday", () => {
-  const tuesdayAt1830 = new Date("2024-01-16T18:30:00.000Z") // Tuesday exactly 18:30 UTC
-  const result = getLastTuesday1830(tuesdayAt1830)
-  expect(result.toISOString()).toBe("2024-01-16T18:30:00.000Z")
+// Given Wednesday Jan 17 at 19:00 UTC, this helper should return the start of
+// that reporting window: Tuesday Jan 16 at 18:00 UTC.
+test("getLastTuesday1800: returns contribution overview start date", () => {
+  const date = new Date("2024-01-17T19:00:00.000Z")
+  const result = getLastTuesday1800(date)
+  expect(result.toISOString()).toBe("2024-01-16T18:00:00.000Z")
 })

--- a/tests/test-date-calc.test.ts
+++ b/tests/test-date-calc.test.ts
@@ -105,6 +105,17 @@ test("getContributionOverviewWindow: Tuesday at cutoff closes previous week", ()
   expect(result.endDate.toISOString()).toBe("2024-01-16T18:00:00.000Z")
 })
 
+// Given Wednesday Jan 17 at 10:00 UTC, Wednesday's 18:00 UTC cutoff has not
+// happened yet. The latest 18:00 UTC cutoff is Tuesday Jan 16, so the report
+// should still cover the completed previous week from Tuesday Jan 9 at 18:00 UTC
+// through Tuesday Jan 16 at 18:00 UTC.
+test("getContributionOverviewWindow: Wednesday morning runs the completed previous week", () => {
+  const wednesdayMorning = new Date("2024-01-17T10:00:00.000Z")
+  const result = getContributionOverviewWindow(wednesdayMorning)
+  expect(result.startDate.toISOString()).toBe("2024-01-09T18:00:00.000Z")
+  expect(result.endDate.toISOString()).toBe("2024-01-16T18:00:00.000Z")
+})
+
 // Given Wednesday Jan 17 at 19:00 UTC, Tuesday's weekly cutoff has already
 // happened. The report should cover the new week from Tuesday Jan 16 at
 // 18:00 UTC through Wednesday Jan 17 at 18:00 UTC.


### PR DESCRIPTION
 Updates weekly and manual overview generation to use a reporting window ending at
  the latest completed 18:00 UTC cutoff.

  Tuesday at 18:00 UTC now closes the previous reporting week instead of starting a
  new one, so a Tuesday run covers the prior Tuesday 18:00 UTC through the current
  Tuesday 18:00 UTC. Runs before 18:00 UTC end at the previous day’s cutoff.

  Adds date-window helpers and tests for Tuesday morning, Tuesday cutoff, Wednesday
  runs, and month/year boundaries.