### PR TITLE
Merge renamed contributor accounts into one canonical username

### DIFF
--- a/frontend/src/hooks/useContributors.ts
+++ b/frontend/src/hooks/useContributors.ts
@@ -1,4 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { getCanonicalUsername } from "lib/contributor-aliases"
+import {
+  combineStats,
+  mergeAliasedContributors,
+} from "lib/merge-contributor-stats"
 import { getContributionOverviewsUrl, getPrAnalysisUrl } from "../constants/api"
 import {
   type ContributorStats,
@@ -174,6 +179,9 @@ export function useContributors(): UseContributorsReturn {
         const prsByContributor: Record<string, PrAnalysisResult[]> = {}
         const prsByRepo: Record<string, PrAnalysisResult[]> = {}
         for (const pr of prAnalysis) {
+          // Normalize a renamed account to its current login so the PR shows up
+          // under one contributor everywhere it's listed.
+          pr.contributor = getCanonicalUsername(pr.contributor)
           if (!prsByRepo[pr.repo]) {
             prsByRepo[pr.repo] = []
           }
@@ -184,7 +192,12 @@ export function useContributors(): UseContributorsReturn {
           prsByContributor[pr.contributor].push(pr)
         }
 
-        setContributorsByUsername(latestContributorsJson)
+        setContributorsByUsername(
+          mergeAliasedContributors(latestContributorsJson) as unknown as Record<
+            string,
+            ContributorStats
+          >,
+        )
         setJsonRecords(validHistoricalRecords)
         setPrsResultant({
           prsByContributors: prsByContributor,
@@ -226,11 +239,18 @@ export function useContributors(): UseContributorsReturn {
       const records: { date: Date; [key: string]: any }[] = []
 
       for (const record of jsonRecords) {
-        if (!record[username]) continue
+        const aliasKeys = Object.keys(record).filter(
+          (key) => key !== "date" && getCanonicalUsername(key) === username,
+        )
+        if (aliasKeys.length === 0) continue
         const timestamp = new Date(record.date).getTime()
         if (seen.has(timestamp)) continue
         seen.add(timestamp)
-        records.push({ date: new Date(record.date), ...record[username] })
+        const combined = aliasKeys.reduce<Record<string, unknown>>(
+          (acc, key) => combineStats(acc, record[key]),
+          {},
+        )
+        records.push({ date: new Date(record.date), ...combined })
       }
 
       records.sort((a, b) => a.date.getTime() - b.date.getTime())

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ import { getRepos } from "lib/data-retrieval/getRepos"
 import { processDiscussionsForContributors } from "lib/data-retrieval/processDiscussions"
 import { postMergeComment } from "lib/notifications/notify-pr-change"
 import { SENIOR_STAFF_USERNAMES } from "lib/constants"
+import { getCanonicalUsername } from "lib/contributor-aliases"
 import type { AnalyzedPR, ContributorStats } from "lib/types"
 import { fetchCodeownersFile } from "lib/utils/code-owner-utils"
 
@@ -58,7 +59,7 @@ export async function generateOverview(
         continue
       }
 
-      const contributor = pr.user.login
+      const contributor = getCanonicalUsername(pr.user.login)
       if (!contributorData[contributor]) {
         contributorData[contributor] = {
           reviewsReceived: 0,
@@ -144,9 +145,10 @@ export async function generateOverview(
 
       if (pr.reviewsByUser) {
         Object.entries(pr.reviewsByUser).forEach(
-          ([reviewer, reviewerStats]) => {
+          ([rawReviewer, reviewerStats]) => {
+            const reviewer = getCanonicalUsername(rawReviewer)
             const isReviewerRepoOwner = repoOwners.some((content) =>
-              content.owners.includes(reviewer),
+              content.owners.includes(rawReviewer),
             )
             if (!contributorData[reviewer]) {
               contributorData[reviewer] = {

--- a/lib/ai-stuff/analyze-pr.ts
+++ b/lib/ai-stuff/analyze-pr.ts
@@ -5,6 +5,7 @@ import { generateAnalyzePRPrompt } from "lib/ai-stuff/prompts"
 import { generateAiObjectCached } from "./sdk"
 import { pr_attribute_schema } from "./pr-attributes"
 import { getContributionStarRatingFromAttributes } from "./getConstributionStarRatingFromAttributes"
+import { getCanonicalUsername } from "lib/contributor-aliases"
 
 const prSchema = z
   .object({
@@ -52,7 +53,7 @@ export async function analyzePRWithAI(
     state: pr.state,
     number: result.object.number,
     title: result.object.title,
-    contributor: result.object.contributor,
+    contributor: getCanonicalUsername(result.object.contributor),
     repo: result.object.repo,
     url: result.object.url,
     isAlignedWithMilestone: false,

--- a/lib/contributor-aliases.ts
+++ b/lib/contributor-aliases.ts
@@ -1,0 +1,16 @@
+/**
+ * Maps a contributor's old GitHub login to their current (canonical) login.
+ *
+ * When someone renames their GitHub account, older PRs, weekly overviews and
+ * cached PR analyses keep the old login while new data uses the new one, so the
+ * tracker counts them as two separate contributors. Add an entry here
+ * (old login -> current login) to merge the two identities everywhere they are
+ * aggregated (overview tables, PRs by contributor, sponsorship totals).
+ */
+export const CONTRIBUTOR_ALIASES: Record<string, string> = {
+  "technologyet31-create": "abdalraof-albarbar",
+}
+
+/** Returns the canonical login for a username, or the username itself. */
+export const getCanonicalUsername = (username: string): string =>
+  CONTRIBUTOR_ALIASES[username] ?? username

--- a/lib/data-processing/storePrAnalysis.ts
+++ b/lib/data-processing/storePrAnalysis.ts
@@ -1,5 +1,6 @@
 import type { AnalyzedPR } from "lib/types"
 import fs from "fs"
+import { getCanonicalUsername } from "lib/contributor-aliases"
 
 export interface StoredPrAnalysis extends AnalyzedPR {
   tag: string
@@ -14,7 +15,13 @@ export const loadPrAnalysis = (weekStartDate: string): StoredPrAnalysis[] => {
   }
   try {
     const content = fs.readFileSync(filePath, "utf-8")
-    return JSON.parse(content) as StoredPrAnalysis[]
+    // Heal renamed accounts (see contributor-aliases) so cached analyses
+    // aggregate under one login in generated markdown and are rewritten to the
+    // canonical login the next time this week is stored.
+    return (JSON.parse(content) as StoredPrAnalysis[]).map((pr) => ({
+      ...pr,
+      contributor: getCanonicalUsername(pr.contributor),
+    }))
   } catch (e) {
     console.error(`Failed to load PR analysis from ${filePath}`, e)
     return []

--- a/lib/merge-contributor-stats.ts
+++ b/lib/merge-contributor-stats.ts
@@ -1,0 +1,53 @@
+import { getCanonicalUsername } from "./contributor-aliases"
+import { scoreToStarString } from "./scoring/scoreToStars"
+
+type StatRecord = Record<string, unknown>
+
+/**
+ * Combines the per-week stats of two accounts: numbers are summed, arrays
+ * concatenated, and any other field keeps the first value seen. Used to merge a
+ * contributor's old login into their current one.
+ */
+export function combineStats(a: StatRecord, b: StatRecord): StatRecord {
+  const out: StatRecord = { ...a }
+  for (const key of Object.keys(b)) {
+    const prev = out[key]
+    const next = b[key]
+    if (typeof prev === "number" && typeof next === "number") {
+      out[key] = prev + next
+    } else if (Array.isArray(prev) && Array.isArray(next)) {
+      out[key] = [...prev, ...next]
+    } else if (prev === undefined) {
+      out[key] = next
+    }
+  }
+  return out
+}
+
+/**
+ * Collapses aliased logins (see contributor-aliases) into their canonical login,
+ * summing stats and recomputing the star string from the combined score. The
+ * result is order-independent for the numeric/array fields.
+ */
+export function mergeAliasedContributors(
+  raw: Record<string, StatRecord>,
+): Record<string, StatRecord> {
+  const merged: Record<string, StatRecord> = {}
+  const wasMerged = new Set<string>()
+  for (const [username, stats] of Object.entries(raw)) {
+    const canonical = getCanonicalUsername(username)
+    const current = merged[canonical]
+    if (!current) {
+      merged[canonical] = { ...stats }
+      continue
+    }
+    merged[canonical] = combineStats(current, stats)
+    wasMerged.add(canonical)
+  }
+  for (const canonical of wasMerged) {
+    merged[canonical].stars = scoreToStarString(
+      (merged[canonical].score as number) ?? 0,
+    )
+  }
+  return merged
+}

--- a/scripts/generate-sponsorship-csv.ts
+++ b/scripts/generate-sponsorship-csv.ts
@@ -14,6 +14,7 @@ import {
   filterHardwareReimbursementsForMonth,
   readHardwareReimbursements,
 } from "../lib/hardware-reimbursements"
+import { getCanonicalUsername } from "../lib/contributor-aliases"
 
 interface ContributorData {
   stars?: string
@@ -128,7 +129,10 @@ function calculateSponsorship(weeksWithDates: WeeklyDataWithDates[]): {
   // Collect data from all weeks
   weeksWithDates.forEach(
     ({ data: weekData, weekStartDate, weekEndDate }, weekIndex) => {
-      Object.entries(weekData).forEach(([username, data]) => {
+      Object.entries(weekData).forEach(([rawUsername, data]) => {
+        // Merge renamed accounts into their current login so a rename mid-month
+        // doesn't split someone's weekly scores across two usernames.
+        const username = getCanonicalUsername(rawUsername)
         // Skip full-timers
         if (STAFF_USERNAMES.includes(username)) return
 

--- a/tests/test-contributor-aliases.test.ts
+++ b/tests/test-contributor-aliases.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import {
+  CONTRIBUTOR_ALIASES,
+  getCanonicalUsername,
+} from "../lib/contributor-aliases"
+
+describe("getCanonicalUsername", () => {
+  test("maps an aliased login to its canonical login", () => {
+    expect(getCanonicalUsername("technologyet31-create")).toBe(
+      "abdalraof-albarbar",
+    )
+  })
+
+  test("returns unknown logins unchanged", () => {
+    expect(getCanonicalUsername("seveibar")).toBe("seveibar")
+  })
+
+  test("is idempotent on canonical logins", () => {
+    for (const canonical of Object.values(CONTRIBUTOR_ALIASES)) {
+      expect(getCanonicalUsername(canonical)).toBe(canonical)
+    }
+  })
+})

--- a/tests/test-merge-contributor-stats.test.ts
+++ b/tests/test-merge-contributor-stats.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import {
+  combineStats,
+  mergeAliasedContributors,
+} from "../lib/merge-contributor-stats"
+import { scoreToStarString } from "../lib/scoring/scoreToStars"
+
+describe("combineStats", () => {
+  test("sums numbers, concatenates arrays, keeps first-defined otherwise", () => {
+    const a = { score: 3, prsMerged: 1, links: ["x"], stars: "first" }
+    const b = { score: 8, prsMerged: 2, links: ["y"], issues: 5 }
+    expect(combineStats(a, b)).toEqual({
+      score: 11,
+      prsMerged: 3,
+      links: ["x", "y"],
+      stars: "first",
+      issues: 5,
+    })
+  })
+})
+
+describe("mergeAliasedContributors", () => {
+  const raw = () => ({
+    "abdalraof-albarbar": {
+      score: 8,
+      prsMerged: 6,
+      reviewsReceived: 17,
+      stars: "⭐",
+    },
+    "technologyet31-create": {
+      score: 6,
+      prsMerged: 3,
+      reviewsReceived: 6,
+      stars: "⭐",
+    },
+    seveibar: { score: 22, prsMerged: 3, reviewsReceived: 0, stars: "⭐⭐" },
+  })
+
+  test("merges an aliased login into its canonical login and recomputes stars", () => {
+    const merged = mergeAliasedContributors(raw())
+    expect(merged["technologyet31-create"]).toBeUndefined()
+    expect(merged["abdalraof-albarbar"]).toMatchObject({
+      score: 14,
+      prsMerged: 9,
+      reviewsReceived: 23,
+    })
+    expect(merged["abdalraof-albarbar"].stars).toBe(scoreToStarString(14))
+  })
+
+  test("is order-independent for the merged totals and stars", () => {
+    const forward = raw()
+    const reversed = {
+      "technologyet31-create": forward["technologyet31-create"],
+      "abdalraof-albarbar": forward["abdalraof-albarbar"],
+    }
+    const a = mergeAliasedContributors(forward)["abdalraof-albarbar"]
+    const b = mergeAliasedContributors(reversed)["abdalraof-albarbar"]
+    expect(b.score).toBe(a.score)
+    expect(b.prsMerged).toBe(a.prsMerged)
+    expect(b.reviewsReceived).toBe(a.reviewsReceived)
+    expect(b.stars).toBe(a.stars)
+  })
+
+  test("leaves a non-aliased contributor untouched", () => {
+    const merged = mergeAliasedContributors(raw())
+    expect(merged.seveibar).toEqual(raw().seveibar)
+  })
+})

--- a/tests/test-renamed-contributor-repro.test.ts
+++ b/tests/test-renamed-contributor-repro.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { loadPrAnalysis } from "../lib/data-processing/storePrAnalysis"
+
+// test.failing exists in the Bun runtime but isn't in this repo's bun-types yet.
+declare module "bun:test" {
+  interface Test {
+    failing(label: string, fn: () => void | Promise<unknown>): void
+  }
+}
+
+// Repro for the renamed-contributor bug: when a contributor renames their GitHub
+// account, cached PR analyses keep the OLD login while newer PRs use the new one,
+// so the tracker counts one person as two (two overview cards, two "PRs by
+// contributor" groups, split sponsorship totals).
+//
+// pr-analysis/2026-07-07.json really contains PRs cached under BOTH
+// technologyet31-create (pre-rename) and abdalraof-albarbar (post-rename) for the
+// same person. This assertion fails on main; it is marked test.failing so CI
+// stays green until the fix canonicalizes the login on load.
+
+describe("renamed contributor is counted once (repro)", () => {
+  test.failing(
+    "cached PRs from before a rename load under the current login",
+    () => {
+      const prs = loadPrAnalysis("2026-07-07")
+      const renamed = prs.filter(
+        (pr) =>
+          pr.contributor === "abdalraof-albarbar" ||
+          pr.contributor === "technologyet31-create",
+      )
+      // Sanity: this week really contains the renamed contributor's PRs.
+      expect(renamed.length).toBeGreaterThan(0)
+      // The bug: those PRs load under two logins instead of one.
+      const logins = [...new Set(renamed.map((pr) => pr.contributor))]
+      expect(logins).toEqual(["abdalraof-albarbar"])
+    },
+  )
+})

--- a/tests/test-renamed-contributor-repro.test.ts
+++ b/tests/test-renamed-contributor-repro.test.ts
@@ -1,38 +1,27 @@
 import { describe, expect, test } from "bun:test"
 import { loadPrAnalysis } from "../lib/data-processing/storePrAnalysis"
 
-// test.failing exists in the Bun runtime but isn't in this repo's bun-types yet.
-declare module "bun:test" {
-  interface Test {
-    failing(label: string, fn: () => void | Promise<unknown>): void
-  }
-}
-
-// Repro for the renamed-contributor bug: when a contributor renames their GitHub
-// account, cached PR analyses keep the OLD login while newer PRs use the new one,
-// so the tracker counts one person as two (two overview cards, two "PRs by
-// contributor" groups, split sponsorship totals).
+// Regression test for the renamed-contributor bug: when a contributor renames
+// their GitHub account, cached PR analyses keep the OLD login while newer PRs use
+// the new one. Without canonicalization the tracker counts one person as two
+// (two overview cards, two "PRs by contributor" groups, split sponsorship totals).
 //
-// pr-analysis/2026-07-07.json really contains PRs cached under BOTH
-// technologyet31-create (pre-rename) and abdalraof-albarbar (post-rename) for the
-// same person. This assertion fails on main; it is marked test.failing so CI
-// stays green until the fix canonicalizes the login on load.
+// pr-analysis/2026-07-07.json contains PRs cached under both technologyet31-create
+// (pre-rename) and abdalraof-albarbar (post-rename); loadPrAnalysis must return
+// them under the single current login.
 
-describe("renamed contributor is counted once (repro)", () => {
-  test.failing(
-    "cached PRs from before a rename load under the current login",
-    () => {
-      const prs = loadPrAnalysis("2026-07-07")
-      const renamed = prs.filter(
-        (pr) =>
-          pr.contributor === "abdalraof-albarbar" ||
-          pr.contributor === "technologyet31-create",
-      )
-      // Sanity: this week really contains the renamed contributor's PRs.
-      expect(renamed.length).toBeGreaterThan(0)
-      // The bug: those PRs load under two logins instead of one.
-      const logins = [...new Set(renamed.map((pr) => pr.contributor))]
-      expect(logins).toEqual(["abdalraof-albarbar"])
-    },
-  )
+describe("renamed contributor is counted once", () => {
+  test("cached PRs from before a rename load under the current login", () => {
+    const prs = loadPrAnalysis("2026-07-07")
+    const renamed = prs.filter(
+      (pr) =>
+        pr.contributor === "abdalraof-albarbar" ||
+        pr.contributor === "technologyet31-create",
+    )
+    // Sanity: this week really contains the renamed contributor's PRs.
+    expect(renamed.length).toBeGreaterThan(0)
+    // They must load under one login, not two.
+    const logins = [...new Set(renamed.map((pr) => pr.contributor))]
+    expect(logins).toEqual(["abdalraof-albarbar"])
+  })
 })


### PR DESCRIPTION
When someone renames their GitHub account the tracker splits them in two — old PRs, weekly overviews and cached analyses keep the old login while new data uses the new one, so you end up with two overview cards, two "PRs by contributor" groups, and split sponsorship totals for one person.

This adds a small `contributor-aliases` map + `getCanonicalUsername()` and applies it wherever contributors are aggregated: overview generation and cached PR analyses (so regenerated markdown/README and the stored `pr-analysis` JSON heal to the canonical login), the frontend tables/graph, and the monthly sponsorship CSV. Merge helpers are factored into `lib/merge-contributor-stats.ts` with unit tests. Future renames are just one line in `contributor-aliases`.
