### PR TITLE
Only cap tiny PR scoring

### DIFF
--- a/docs/sponsorship-calculation-explanation.md
+++ b/docs/sponsorship-calculation-explanation.md
@@ -14,7 +14,7 @@ This document explains how contribution points, scores, and sponsorship tiers ar
 
 ### Overview
 
-PRs are analyzed by AI and assigned a **star rating (1-3 stars)**. 4 and 5 star ratings can only be manually assigned by staff. Weekly scores use `2^(starRating - 1)` per PR (capped at 12 PRs per rating), plus review/discussion points.
+PRs are analyzed by AI and assigned a **star rating (1-3 stars)**. 4 and 5 star ratings can only be manually assigned by staff. Weekly scores use `2^(starRating - 1)` per PR, with 1-star PRs capped at 12 per week, plus review/discussion points.
 
 ### Weekly Score → Star String
 

--- a/lib/data-processing/generateSponsorshipExplanationMarkdown.ts
+++ b/lib/data-processing/generateSponsorshipExplanationMarkdown.ts
@@ -21,7 +21,7 @@ export const generateSponsorshipExplanationMarkdown = () => {
   markdown += "## Scoring & Sponsorship System\n\n"
   markdown += "### Overview\n\n"
   markdown +=
-    "PRs are analyzed by AI and assigned a **star rating (1-3 stars)**. 4 and 5 star ratings can only be manually assigned by staff. Weekly scores use `2^(starRating - 1)` per PR (capped at 12 PRs per rating), plus review/discussion points.\n\n"
+    "PRs are analyzed by AI and assigned a **star rating (1-3 stars)**. 4 and 5 star ratings can only be manually assigned by staff. Weekly scores use `2^(starRating - 1)` per PR, with 1-star PRs capped at 12 per week, plus review/discussion points.\n\n"
 
   markdown += "### Weekly Score → Star String\n\n"
   markdown += "| Score Range | Star String | Count Value |\n"

--- a/lib/scoring/getContributorScore.ts
+++ b/lib/scoring/getContributorScore.ts
@@ -71,7 +71,9 @@ export function getContributorScore({
     if (pr.starRating !== undefined) {
       result[`rating${pr.starRating}Count`]++
 
-      if (result[`rating${pr.starRating}Count`] <= 12) {
+      const isWithinTinyPrCap = pr.starRating !== 1 || result.rating1Count <= 12
+
+      if (isWithinTinyPrCap) {
         result.score += 2 ** ((pr.starRating ?? 0) - 1)
       }
     }

--- a/tests/test-pr-scoring.test.ts
+++ b/tests/test-pr-scoring.test.ts
@@ -3,6 +3,45 @@ import { getContributorScore } from "lib/scoring/getContributorScore"
 import { MAINTAINERS } from "lib/scoring/maintainers"
 import type { AnalyzedPR, ContributorStats } from "lib/types"
 
+const createPRs = (
+  starRating: AnalyzedPR["starRating"],
+  impact: AnalyzedPR["impact"],
+  count: number,
+): AnalyzedPR[] =>
+  Array.from({ length: count }, () => ({ starRating, impact }) as AnalyzedPR)
+
+describe("PR scoring caps", () => {
+  it("should cap tiny PRs at 12", () => {
+    const result = getContributorScore({
+      contributorPRs: createPRs(1, "Tiny", 13),
+      contributorStats: undefined,
+    })
+
+    expect(result.rating1Count).toBe(13)
+    expect(result.score).toBe(12)
+  })
+
+  it("should not cap minor PRs", () => {
+    const result = getContributorScore({
+      contributorPRs: createPRs(2, "Minor", 13),
+      contributorStats: undefined,
+    })
+
+    expect(result.rating2Count).toBe(13)
+    expect(result.score).toBe(26)
+  })
+
+  it("should not cap major PRs", () => {
+    const result = getContributorScore({
+      contributorPRs: createPRs(3, "Major", 13),
+      contributorStats: undefined,
+    })
+
+    expect(result.rating3Count).toBe(13)
+    expect(result.score).toBe(52)
+  })
+})
+
 it("should count distinct PRs reviewed", () => {
   const mockPRs: AnalyzedPR[] = []
   const stats: ContributorStats = {


### PR DESCRIPTION
## Summary

- keep the weekly 12-PR scoring cap for 1-star (tiny) contributions
- count every 2-star-and-higher contribution toward the weekly score
- add regression coverage for tiny, minor, and major PR totals
- update the sponsorship scoring explanation to describe the tiny-only cap

## Why

The score guard used the count for whichever rating was being processed, so the 12-PR limit applied to every rating. The cap is intended only for tiny contributions; higher-impact work should continue contributing to the weekly score.

## Impact

Contributors can now receive points for all minor, major, and manually rated higher-impact PRs in a week. Tiny PRs remain capped at 12.

## Validation

- `bun test` (43 passing)
- `bun run format:check`
- `bun run build`
- `git diff --check`
