### PR TITLE
fix: paginate GitHub list calls in data-retrieval

### DIFF
--- a/lib/data-retrieval/getBountiedIssues.ts
+++ b/lib/data-retrieval/getBountiedIssues.ts
@@ -1,4 +1,9 @@
 import { octokit } from "lib/sdks"
+import { GITHUB_PAGE_SIZE } from "./pagination"
+
+type RepoIssue = Awaited<
+  ReturnType<typeof octokit.issues.listForRepo>
+>["data"][number]
 
 // Function to extract bounty amount from the comment body
 function extractBountyAmountFromComment(commentBody: string): number {
@@ -17,14 +22,22 @@ export async function getBountiedIssues(
   startDate: string,
 ): Promise<{ number: number; amount: number }[]> {
   try {
-    const { data: issues } = await octokit.issues.listForRepo({
-      owner: repo.split("/")[0],
-      repo: repo.split("/")[1],
-      creator: contributor,
-      since: startDate,
-      state: "all",
-      labels: "💎 Bounty", // Filter issues by the bounty label directly
-    })
+    const fetchBountiedIssues = async (page = 1): Promise<RepoIssue[]> => {
+      const { data } = await octokit.issues.listForRepo({
+        owner: repo.split("/")[0],
+        repo: repo.split("/")[1],
+        creator: contributor,
+        since: startDate,
+        state: "all",
+        labels: "💎 Bounty", // Filter issues by the bounty label directly
+        per_page: GITHUB_PAGE_SIZE,
+        page,
+      })
+      if (data.length < GITHUB_PAGE_SIZE) return data
+      return [...data, ...(await fetchBountiedIssues(page + 1))]
+    }
+
+    const issues = await fetchBountiedIssues()
 
     // Filter out pull requests by checking for the absence of `pull_request` property
     const openedBountiedIssues = issues.filter((issue) => !issue.pull_request)

--- a/lib/data-retrieval/getIssuesCreated.ts
+++ b/lib/data-retrieval/getIssuesCreated.ts
@@ -1,4 +1,9 @@
 import { octokit } from "lib/sdks"
+import { GITHUB_PAGE_SIZE } from "./pagination"
+
+type RepoIssue = Awaited<
+  ReturnType<typeof octokit.issues.listForRepo>
+>["data"][number]
 
 export async function getIssuesCreated(
   repo: string,
@@ -6,13 +11,21 @@ export async function getIssuesCreated(
   startDate: string,
 ): Promise<{ totalIssues: number; majorIssues: number }> {
   try {
-    const { data: issues } = await octokit.issues.listForRepo({
-      owner: repo.split("/")[0],
-      repo: repo.split("/")[1],
-      creator: contributor,
-      since: startDate,
-      state: "all",
-    })
+    const fetchIssues = async (page = 1): Promise<RepoIssue[]> => {
+      const { data } = await octokit.issues.listForRepo({
+        owner: repo.split("/")[0],
+        repo: repo.split("/")[1],
+        creator: contributor,
+        since: startDate,
+        state: "all",
+        per_page: GITHUB_PAGE_SIZE,
+        page,
+      })
+      if (data.length < GITHUB_PAGE_SIZE) return data
+      return [...data, ...(await fetchIssues(page + 1))]
+    }
+
+    const issues = await fetchIssues()
 
     // Filter out pull requests by checking for the absence of `pull_request` property
     const openedIssues = issues.filter((issue) => !issue.pull_request)

--- a/lib/data-retrieval/getMergedPRs.ts
+++ b/lib/data-retrieval/getMergedPRs.ts
@@ -3,6 +3,11 @@ import { filterDiff } from "lib/data-processing/filter-diff"
 import { octokit } from "lib/sdks"
 import type { MergedPullRequest } from "lib/types"
 import { batchProcess } from "../utils/batch-process"
+import { GITHUB_PAGE_SIZE, hasMorePagesInWindow } from "./pagination"
+
+type ClosedPullRequest = Awaited<
+  ReturnType<typeof octokit.pulls.list>
+>["data"][number]
 
 export async function getMergedPRs(
   repo: string,
@@ -10,18 +15,25 @@ export async function getMergedPRs(
   currentTime: Date = new Date(),
 ): Promise<MergedPullRequest[]> {
   const [owner, repo_name] = repo.split("/")
-  const { data } = await octokit.pulls.list({
-    owner,
-    repo: repo_name,
-    state: "closed",
-    sort: "updated",
-    direction: "desc",
-    per_page: 100,
-  })
-
   const sinceDate = new Date(since)
+
+  const fetchClosedPRs = async (page = 1): Promise<ClosedPullRequest[]> => {
+    const { data } = await octokit.pulls.list({
+      owner,
+      repo: repo_name,
+      state: "closed",
+      sort: "updated",
+      direction: "desc",
+      per_page: GITHUB_PAGE_SIZE,
+      page,
+    })
+    if (!hasMorePagesInWindow(data, sinceDate)) return data
+    return [...data, ...(await fetchClosedPRs(page + 1))]
+  }
+
+  const closedPRs = await fetchClosedPRs()
   const currentTimeMs = currentTime.getTime()
-  const filteredPRs = data.filter((pr) => {
+  const filteredPRs = closedPRs.filter((pr) => {
     if (!pr.merged_at) return false
     const mergedTime = new Date(pr.merged_at).getTime()
     const inRange =

--- a/lib/data-retrieval/getOpenedPRs.ts
+++ b/lib/data-retrieval/getOpenedPRs.ts
@@ -1,23 +1,36 @@
 import { filterDiff } from "lib/data-processing/filter-diff"
 import { octokit } from "lib/sdks"
 import type { MergedPullRequest } from "lib/types"
+import { GITHUB_PAGE_SIZE, hasMorePagesInWindow } from "./pagination"
+
+type OpenPullRequest = Awaited<
+  ReturnType<typeof octokit.pulls.list>
+>["data"][number]
 
 export async function getOpenedPRs(
   repo: string,
   since: string,
 ): Promise<MergedPullRequest[]> {
   const [owner, repo_name] = repo.split("/")
-  const { data: prs } = await octokit.pulls.list({
-    owner,
-    repo: repo_name,
-    state: "open",
-    sort: "updated",
-    direction: "desc",
-    per_page: 100,
-  })
+  const sinceDate = new Date(since)
 
+  const fetchOpenPRs = async (page = 1): Promise<OpenPullRequest[]> => {
+    const { data } = await octokit.pulls.list({
+      owner,
+      repo: repo_name,
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: GITHUB_PAGE_SIZE,
+      page,
+    })
+    if (!hasMorePagesInWindow(data, sinceDate)) return data
+    return [...data, ...(await fetchOpenPRs(page + 1))]
+  }
+
+  const prs = await fetchOpenPRs()
   const filteredPRs = prs.filter(
-    (pr) => new Date(pr.created_at).getTime() >= new Date(since).getTime(),
+    (pr) => new Date(pr.created_at).getTime() >= sinceDate.getTime(),
   )
 
   // Fetch diff content for each PR

--- a/lib/data-retrieval/pagination.ts
+++ b/lib/data-retrieval/pagination.ts
@@ -1,0 +1,19 @@
+export const GITHUB_PAGE_SIZE = 100
+
+/**
+ * `pulls.list` results are sorted by `updated_at` descending, and a pull
+ * request's `updated_at` is never earlier than its `created_at` or `merged_at`.
+ * So once a full page ends before the window start, no later page can hold a
+ * pull request that opened or merged inside the window.
+ */
+export function hasMorePagesInWindow(
+  pageItems: { updated_at?: string | null }[],
+  since: Date,
+): boolean {
+  if (pageItems.length < GITHUB_PAGE_SIZE) return false
+
+  const lastUpdatedAt = pageItems[pageItems.length - 1]?.updated_at
+  if (!lastUpdatedAt) return true
+
+  return new Date(lastUpdatedAt).getTime() >= since.getTime()
+}

--- a/tests/test-pagination-window.test.ts
+++ b/tests/test-pagination-window.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import {
+  GITHUB_PAGE_SIZE,
+  hasMorePagesInWindow,
+} from "../lib/data-retrieval/pagination"
+
+const since = new Date("2026-07-21T18:00:00Z")
+
+const page = (lastUpdatedAt: string | null, size = GITHUB_PAGE_SIZE) =>
+  Array.from({ length: size }, (_, index) => ({
+    updated_at: index === size - 1 ? lastUpdatedAt : "2026-07-28T00:00:00Z",
+  }))
+
+test("stops on a partial page", () => {
+  expect(hasMorePagesInWindow(page("2026-07-28T00:00:00Z", 42), since)).toBe(
+    false,
+  )
+  expect(hasMorePagesInWindow([], since)).toBe(false)
+})
+
+test("keeps paging while a full page still ends inside the window", () => {
+  expect(hasMorePagesInWindow(page("2026-07-22T09:00:00Z"), since)).toBe(true)
+})
+
+test("stops once a full page ends before the window start", () => {
+  expect(hasMorePagesInWindow(page("2026-07-21T17:59:59Z"), since)).toBe(false)
+})
+
+test("treats a page ending exactly on the window start as more to fetch", () => {
+  expect(hasMorePagesInWindow(page("2026-07-21T18:00:00Z"), since)).toBe(true)
+})
+
+test("keeps paging when the last entry has no updated_at", () => {
+  expect(hasMorePagesInWindow(page(null), since)).toBe(true)
+})


### PR DESCRIPTION
# PR: fix: paginate GitHub list calls in data-retrieval

Target: `tscircuit/contribution-tracker`, base `main`, head `Hero988:fix/paginate-data-retrieval`
Prepared: 2026-07-28 (s205). Open at the Tue 18:00Z window.
Local commit: `9b244d1`. CI checks verified locally: `bun test` 50 pass / 0 fail, `bunx tsc --noEmit` clean, `bun run format:check` clean.

---

## Body

`getMergedPRs` reads a single page of `pulls.list`:

```ts
const { data } = await octokit.pulls.list({
  owner,
  repo: repo_name,
  state: "closed",
  sort: "updated",
  direction: "desc",
  per_page: 100,
})
```

There is no `page` loop, so it only ever sees the 100 most recently *updated* closed PRs. On an active repo one reporting week produces more than that, and because the sort key is `updated_at` the page-1 boundary keeps sliding forward as older PRs get touched.

`update-contribution-overview.yml` regenerates the **current** week's overview every day at 18:00 UTC. So a PR merged early in the week can be inside page 1 on Wednesday and outside it by Friday — at which point it drops out of the overview, even though its analysis is already stored in `pr-analysis/`.

### Measured against the live API

`getMergedPRs("tscircuit/core", "2026-07-21T18:00:00Z", 2026-07-28T18:00:00Z)`:

| | merged PRs returned |
|---|---|
| `main` | 50 |
| this branch | 75 |

Page 1's tail was `2026-07-23T18:26:00Z`, so the whole first half of the window was cut — 25 PRs merged between Jul 21 18:46Z and Jul 23 17:26Z, from 8 different contributors. For the preceding week (`2026-07-14` → `2026-07-21`) page 1 no longer reaches the window at all: 0 of 39.

### Visible in this repo's own history

Same file, `contribution-overviews/2026-07-21.json`, across four consecutive daily regenerations of that one *finished* week:

| regenerated | imrishabh18 | Hero988 | MustafaMulla29 | total score |
|---|---|---|---|---|
| 2026-07-24 | 57.5 (5 major) | 10 (2 major) | 19 (2 major) | 420.5 |
| 2026-07-25 | 75.5 (8 major) | 15 (3 major) | 19 (2 major) | 516.5 |
| 2026-07-26 | 97.5 (10 major) | 15 (3 major) | 19 (2 major) | 587.5 |
| 2026-07-27 | 89.5 (8 major) | 7 (1 major) | 16 (1 major) | 643.0 |

Four contributors lost score on the 26th → 27th regeneration alone, 20 points total.

The clearest signature is `MustafaMulla29`: `prsMerged` went **10 → 16** across those runs while `score` went **19 → 16** and major **2 → 1**. More merged PRs, less credit. That divergence happens because `prsMerged` is counted from `getAllPRs` (index.ts:166), which *does* paginate, while the score comes from the `getMergedPRs` path (index.ts:187), which does not — so the two numbers in the same report disagree.

It stays hidden because the aggregate keeps rising (587.5 → 643.0) as new merges land faster than old ones fall off; only individual rows go backwards. Closed issue #267 ("Score inconsistent") looks like an earlier report of the same symptom.

Disclosure: I noticed this because my own row moved backwards, but as the table shows it is not specific to me.

## The fix

Adds `lib/data-retrieval/pagination.ts` with a shared termination predicate:

```ts
export function hasMorePagesInWindow(
  pageItems: { updated_at?: string | null }[],
  since: Date,
): boolean
```

Results are sorted by `updated_at` descending, and a PR's `updated_at` is never earlier than its `created_at` or `merged_at`. So once a *full* page ends before the window start, no later page can hold a PR that opened or merged inside the window — the walk stops there rather than reading the repo's whole history.

Three other functions in `lib/data-retrieval` have the same single-page defect, so they are fixed in the same PR:

- `getOpenedPRs` — one page of `state: "open"`; on a repo carrying 100+ open PRs, newly opened ones are dropped.
- `getIssuesCreated` — `issues.listForRepo` with no `per_page`, so it silently uses GitHub's default of **30**.
- `getBountiedIssues` — same, also capped at 30.

The paging loops follow the recursive shape already used by `getAllPRs`, and `getRepos` already does the same thing with a `while` loop, so no new pattern is introduced. `octokit` here is the `CachedOctokit` wrapper, which has no `.paginate`, and it caches per-params — so each page is cached independently.

## Verification

- A/B against the live API on `tscircuit/core` for the current window: 50 → 75 merged PRs, with `#2739` and `#2765` (the two that had silently vanished) restored.
- `tests/test-pagination-window.test.ts` covers the termination predicate: partial page, empty page, full page inside the window, full page before the window, the exact boundary, and a missing `updated_at`.
- `bun test` 50 pass / 0 fail · `bunx tsc --noEmit` clean · `bun run format:check` clean.
