### PR TITLE
Fix contribution pagination and historical README updates

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs"
 import { analyzePRWithAI } from "lib/ai-stuff/analyze-pr"
 import { getContributionOverviewWindow } from "lib/ai/date-utils"
+import { replaceCurrentWeekReadme } from "lib/data-processing/current-week-readme"
 import { generateMarkdown } from "lib/data-processing/generateMarkdown"
 import {
   getOrCreateContributorStats,
@@ -22,9 +23,14 @@ import { SENIOR_STAFF_USERNAMES } from "lib/constants"
 import type { AnalyzedPR, ContributorStats } from "lib/types"
 import { fetchCodeownersFile } from "lib/utils/code-owner-utils"
 
+export interface GenerateOverviewOptions {
+  updateReadme?: boolean
+}
+
 export async function generateOverview(
   startDate: string,
   currentTime: Date = new Date(),
+  options: GenerateOverviewOptions = {},
 ) {
   const seniorStaffUsernames = new Set<string>(SENIOR_STAFF_USERNAMES)
   // Extract date portion for file naming (handles both YYYY-MM-DD and full ISO timestamp)
@@ -315,6 +321,7 @@ export async function generateOverview(
     contributorStatsByLogin,
     startDateString,
     repoOwnersMap,
+    updateReadme: options.updateReadme ?? false,
   })
 }
 
@@ -323,11 +330,13 @@ async function generateAndWriteFiles({
   contributorStatsByLogin,
   startDateString,
   repoOwnersMap,
+  updateReadme,
 }: {
   mergedPrsWithCurrentContributorLogins: AnalyzedPR[]
   contributorStatsByLogin: Record<string, ContributorStats>
   startDateString: string
   repoOwnersMap: Record<string, string[]>
+  updateReadme: boolean
 }) {
   console.log("Generating markdown")
   // Group PRs by contributor
@@ -380,17 +389,16 @@ async function generateAndWriteFiles({
   )
   console.log(`Generated contribution-overviews/${startDateString}.json`)
 
-  // Edit the README.md file
-  const readme = fs.readFileSync("README.md", "utf8")
-  const updatedReadme = readme.replace(
-    /<!-- START_CURRENT_WEEK -->[\s\S]*<!-- END_CURRENT_WEEK -->/m,
-    `<!-- START_CURRENT_WEEK -->\n\n${markdown}\n\n<!-- END_CURRENT_WEEK -->`,
-  )
-  fs.writeFileSync("README.md", updatedReadme)
+  if (updateReadme) {
+    const readme = fs.readFileSync("README.md", "utf8")
+    fs.writeFileSync("README.md", replaceCurrentWeekReadme(readme, markdown))
+  } else {
+    console.log("Skipped README current-week update")
+  }
 }
 
 export async function generateWeeklyOverview() {
   const { startDate, endDate } = getContributionOverviewWindow(new Date())
   const weekStartString = startDate.toISOString()
-  await generateOverview(weekStartString, endDate)
+  await generateOverview(weekStartString, endDate, { updateReadme: true })
 }

--- a/lib/data-processing/current-week-readme.ts
+++ b/lib/data-processing/current-week-readme.ts
@@ -1,0 +1,43 @@
+import { getContributionOverviewWindow } from "lib/ai/date-utils"
+
+const CURRENT_WEEK_START_MARKER = "<!-- START_CURRENT_WEEK -->"
+const CURRENT_WEEK_END_MARKER = "<!-- END_CURRENT_WEEK -->"
+
+export function isCurrentContributionOverview(
+  overviewStartDate: Date | string,
+  overviewEndDate: Date | string,
+  now: Date = new Date(),
+): boolean {
+  const overviewStartTime = new Date(overviewStartDate).getTime()
+  const overviewEndTime = new Date(overviewEndDate).getTime()
+  if (Number.isNaN(overviewStartTime) || Number.isNaN(overviewEndTime)) {
+    return false
+  }
+
+  const { startDate: currentStartDate, endDate: currentEndDate } =
+    getContributionOverviewWindow(now)
+  return (
+    overviewStartTime === currentStartDate.getTime() &&
+    overviewEndTime === currentEndDate.getTime()
+  )
+}
+
+export function replaceCurrentWeekReadme(
+  readme: string,
+  markdown: string,
+): string {
+  const startIndex = readme.indexOf(CURRENT_WEEK_START_MARKER)
+  const endIndex = readme.indexOf(CURRENT_WEEK_END_MARKER)
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error("README current-week markers are missing or out of order")
+  }
+
+  const beforeCurrentWeek = readme.slice(
+    0,
+    startIndex + CURRENT_WEEK_START_MARKER.length,
+  )
+  const afterCurrentWeek = readme.slice(endIndex)
+
+  return `${beforeCurrentWeek}\n\n${markdown}\n\n${afterCurrentWeek}`
+}

--- a/lib/data-retrieval/getMergedPRs.ts
+++ b/lib/data-retrieval/getMergedPRs.ts
@@ -3,6 +3,11 @@ import { filterDiff } from "lib/data-processing/filter-diff"
 import { octokit } from "lib/sdks"
 import type { MergedPullRequest } from "lib/types"
 import { batchProcess } from "../utils/batch-process"
+import { fetchAllPagesInWindow } from "./pagination"
+
+type ClosedPullRequest = Awaited<
+  ReturnType<typeof octokit.pulls.list>
+>["data"][number]
 
 export async function getMergedPRs(
   repo: string,
@@ -10,18 +15,25 @@ export async function getMergedPRs(
   currentTime: Date = new Date(),
 ): Promise<MergedPullRequest[]> {
   const [owner, repo_name] = repo.split("/")
-  const { data } = await octokit.pulls.list({
-    owner,
-    repo: repo_name,
-    state: "closed",
-    sort: "updated",
-    direction: "desc",
-    per_page: 100,
+  const sinceDate = new Date(since)
+  const closedPRs = await fetchAllPagesInWindow<ClosedPullRequest>({
+    since: sinceDate,
+    fetchPage: async (page, perPage) => {
+      const { data } = await octokit.pulls.list({
+        owner,
+        repo: repo_name,
+        state: "closed",
+        sort: "updated",
+        direction: "desc",
+        per_page: perPage,
+        page,
+      })
+      return data
+    },
   })
 
-  const sinceDate = new Date(since)
   const currentTimeMs = currentTime.getTime()
-  const filteredPRs = data.filter((pr) => {
+  const filteredPRs = closedPRs.filter((pr) => {
     if (!pr.merged_at) return false
     const mergedTime = new Date(pr.merged_at).getTime()
     const inRange =

--- a/lib/data-retrieval/pagination.ts
+++ b/lib/data-retrieval/pagination.ts
@@ -1,0 +1,49 @@
+export const GITHUB_PAGE_SIZE = 100
+
+export interface GitHubUpdatedItem {
+  updated_at?: string | null
+}
+
+/**
+ * GitHub results are sorted by `updated_at` descending. A pull request's
+ * `updated_at` cannot be earlier than its `created_at` or `merged_at`, so once
+ * the final item on a full page is older than the reporting window, later
+ * pages cannot contain a pull request created or merged inside that window.
+ */
+export function hasMorePagesInWindow(
+  pageItems: GitHubUpdatedItem[],
+  since: Date,
+  pageSize = GITHUB_PAGE_SIZE,
+): boolean {
+  if (pageItems.length < pageSize) return false
+
+  const lastUpdatedAt = pageItems.at(-1)?.updated_at
+  if (!lastUpdatedAt) return true
+
+  const lastUpdatedTime = new Date(lastUpdatedAt).getTime()
+  if (Number.isNaN(lastUpdatedTime)) return true
+
+  // Keep paging at the exact boundary because equal timestamps can span pages.
+  return lastUpdatedTime >= since.getTime()
+}
+
+export async function fetchAllPagesInWindow<T extends GitHubUpdatedItem>({
+  fetchPage,
+  since,
+  pageSize = GITHUB_PAGE_SIZE,
+}: {
+  fetchPage: (page: number, perPage: number) => Promise<T[]>
+  since: Date
+  pageSize?: number
+}): Promise<T[]> {
+  const allItems: T[] = []
+
+  for (let page = 1; ; page++) {
+    const pageItems = await fetchPage(page, pageSize)
+    allItems.push(...pageItems)
+
+    if (!hasMorePagesInWindow(pageItems, since, pageSize)) {
+      return allItems
+    }
+  }
+}

--- a/scripts/generate-overview-for-date.ts
+++ b/scripts/generate-overview-for-date.ts
@@ -1,5 +1,6 @@
 import { generateOverview } from ".."
 import { getContributionOverviewWindow } from "../lib/ai/date-utils"
+import { isCurrentContributionOverview } from "../lib/data-processing/current-week-readme"
 
 const dateArg = process.argv[2]
 
@@ -38,7 +39,14 @@ console.log(
   `Generating overview from ${weekStartString} to ${endDate.toISOString()}`,
 )
 
-generateOverview(weekStartString, endDate).catch((error) => {
+const updateReadme = isCurrentContributionOverview(startDate, endDate)
+console.log(
+  updateReadme
+    ? "README current-week block will be updated"
+    : "README current-week block will not be updated for this historical window",
+)
+
+generateOverview(weekStartString, endDate, { updateReadme }).catch((error) => {
   console.error(error)
   process.exit(1)
 })

--- a/tests/test-current-week-readme.test.ts
+++ b/tests/test-current-week-readme.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import {
+  isCurrentContributionOverview,
+  replaceCurrentWeekReadme,
+} from "../lib/data-processing/current-week-readme"
+
+test("identifies only the overview for the current reporting window", () => {
+  const now = new Date("2026-08-05T20:15:00Z")
+
+  expect(
+    isCurrentContributionOverview(
+      "2026-08-04T18:00:00Z",
+      "2026-08-05T18:00:00Z",
+      now,
+    ),
+  ).toBe(true)
+  expect(
+    isCurrentContributionOverview(
+      "2026-07-28T18:00:00Z",
+      "2026-08-04T18:00:00Z",
+      now,
+    ),
+  ).toBe(false)
+  expect(
+    isCurrentContributionOverview("not-a-date", "2026-08-05T18:00:00Z", now),
+  ).toBe(false)
+})
+
+test("handles the Tuesday cutoff boundary when deciding the current overview", () => {
+  const beforeCutoff = new Date("2026-08-04T17:59:59Z")
+  const atCutoff = new Date("2026-08-04T18:00:00Z")
+
+  expect(
+    isCurrentContributionOverview(
+      "2026-07-28T18:00:00Z",
+      "2026-08-04T18:00:00Z",
+      beforeCutoff,
+    ),
+  ).toBe(false)
+  expect(
+    isCurrentContributionOverview(
+      "2026-07-28T18:00:00Z",
+      "2026-08-04T18:00:00Z",
+      atCutoff,
+    ),
+  ).toBe(true)
+})
+
+test("replaces only the README current-week block", () => {
+  const readme = [
+    "# Header",
+    "",
+    "<!-- START_CURRENT_WEEK -->",
+    "",
+    "old overview",
+    "",
+    "<!-- END_CURRENT_WEEK -->",
+    "",
+    "Footer",
+  ].join("\n")
+
+  expect(replaceCurrentWeekReadme(readme, "new overview")).toBe(
+    [
+      "# Header",
+      "",
+      "<!-- START_CURRENT_WEEK -->",
+      "",
+      "new overview",
+      "",
+      "<!-- END_CURRENT_WEEK -->",
+      "",
+      "Footer",
+    ].join("\n"),
+  )
+})
+
+test("fails clearly instead of silently skipping malformed README markers", () => {
+  expect(() => replaceCurrentWeekReadme("# README", "overview")).toThrow(
+    "README current-week markers are missing or out of order",
+  )
+})

--- a/tests/test-pagination-window.test.ts
+++ b/tests/test-pagination-window.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import {
+  fetchAllPagesInWindow,
+  GITHUB_PAGE_SIZE,
+  hasMorePagesInWindow,
+} from "../lib/data-retrieval/pagination"
+
+const since = new Date("2026-07-21T18:00:00Z")
+
+const page = (lastUpdatedAt: string | null, size = GITHUB_PAGE_SIZE) =>
+  Array.from({ length: size }, (_, index) => ({
+    updated_at: index === size - 1 ? lastUpdatedAt : "2026-07-28T00:00:00Z",
+  }))
+
+test("stops on an empty or partial page", () => {
+  expect(hasMorePagesInWindow([], since)).toBe(false)
+  expect(hasMorePagesInWindow(page("2026-07-28T00:00:00Z", 42), since)).toBe(
+    false,
+  )
+})
+
+test("keeps paging while a full page still ends inside the window", () => {
+  expect(hasMorePagesInWindow(page("2026-07-22T09:00:00Z"), since)).toBe(true)
+})
+
+test("stops once a full page ends before the window start", () => {
+  expect(hasMorePagesInWindow(page("2026-07-21T17:59:59Z"), since)).toBe(false)
+})
+
+test("keeps paging at the exact boundary so timestamp ties are not lost", () => {
+  expect(hasMorePagesInWindow(page("2026-07-21T18:00:00Z"), since)).toBe(true)
+})
+
+test("keeps paging when the boundary timestamp is missing or invalid", () => {
+  expect(hasMorePagesInWindow(page(null), since)).toBe(true)
+  expect(hasMorePagesInWindow(page("not-a-date"), since)).toBe(true)
+})
+
+test("fetches and combines every page needed for the reporting window", async () => {
+  const pageSize = 2
+  const requestedPages: number[] = []
+  const pages = [
+    [
+      { id: 1, updated_at: "2026-07-23T00:00:00Z" },
+      { id: 2, updated_at: "2026-07-22T00:00:00Z" },
+    ],
+    [{ id: 3, updated_at: "2026-07-21T19:00:00Z" }],
+  ]
+
+  const result = await fetchAllPagesInWindow({
+    since,
+    pageSize,
+    fetchPage: async (requestedPage, perPage) => {
+      requestedPages.push(requestedPage)
+      expect(perPage).toBe(pageSize)
+      return pages[requestedPage - 1] ?? []
+    },
+  })
+
+  expect(requestedPages).toEqual([1, 2])
+  expect(result.map((item) => item.id)).toEqual([1, 2, 3])
+})
+
+test("does not request another page after crossing the window boundary", async () => {
+  const requestedPages: number[] = []
+
+  await fetchAllPagesInWindow({
+    since,
+    pageSize: 2,
+    fetchPage: async (requestedPage) => {
+      requestedPages.push(requestedPage)
+      return [
+        { updated_at: "2026-07-21T17:00:00Z" },
+        { updated_at: "2026-07-21T16:00:00Z" },
+      ]
+    },
+  })
+
+  expect(requestedPages).toEqual([1])
+})


### PR DESCRIPTION
## Summary

- Paginate closed pull requests used for contribution scoring instead of reading only the first 100 results.
- Stop pagination once a full page's oldest `updated_at` is before the reporting window, while continuing at the exact boundary so timestamp ties are not lost.
- Make README current-week replacement explicit and safe by default.
- Let scheduled weekly generation update README, while a dated manual run updates it only when both its start and end cutoffs exactly match the actual current reporting window.
- Add regression coverage for pagination boundaries, multi-page aggregation, Tuesday cutoffs, historical windows, and README block replacement.

## Root cause

`getMergedPRs` requested one page of 100 closed PRs sorted by `updated_at`. On active repositories, valid PRs merged inside the reporting window moved past page 1 as other PRs were updated, so stored analyses remained present but the PRs disappeared from scoring.

Separately, every overview generation unconditionally replaced README's current-week block. A historical manual run could therefore replace the current week with an older report.

## Behavior after this change

- Scoring includes all closed-PR pages that can still contain an in-window merge.
- Pagination remains bounded and does not scan repository history after crossing the reporting-window boundary.
- Scheduled weekly runs continue updating README.
- Historical and monthly generation leave README unchanged.
- A dated manual run can update README only when its complete reporting window is the actual current window.
- Missing or malformed README markers fail clearly rather than silently doing nothing.

## Validation

- `bun test` — 56 pass, 0 fail.
- `node_modules/.bin/tsc --noEmit` — pass.
- `bun run format:check` — pass.
- `bun run build` — pass.
- `git diff --check` — pass.
