### PR TITLE
Exclude sparkfun-boards from contribution scoring

### DIFF
--- a/lib/ai-stuff/getConstributionStarRatingFromAttributes.ts
+++ b/lib/ai-stuff/getConstributionStarRatingFromAttributes.ts
@@ -19,8 +19,6 @@ export const getContributionStarRatingFromAttributes = (
 
   if (a.only_adds_autorouter_fixtures) maxRating = 1
   if (a.minor_developer_experience_improvement) maxRating = 1
-  if (a.introduces_new_circuit_board && repo === "tscircuit/sparkfun-boards")
-    return 3
   if (a.major_autorouter_bug_fix) return 3
   if (a.major_library_algorithm_contribution) return 3
 

--- a/lib/data-retrieval/getRepos.ts
+++ b/lib/data-retrieval/getRepos.ts
@@ -1,11 +1,18 @@
 import { octokit } from "lib/sdks"
 
+const EXCLUDED_REPOS = new Set(["tscircuit/sparkfun-boards"])
+
+export const excludeNonPointAwardingRepos = (repos: string[]): string[] =>
+  repos.filter((repo) => !EXCLUDED_REPOS.has(repo))
+
 export async function getRepos(): Promise<string[]> {
   if (process.env.SHORT_REPO_LIST) {
     if (process.env.SHORT_REPO_LIST.includes("tscircuit/")) {
-      return process.env.SHORT_REPO_LIST.split(",")
+      return excludeNonPointAwardingRepos(
+        process.env.SHORT_REPO_LIST.split(","),
+      )
     }
-    return [
+    return excludeNonPointAwardingRepos([
       "tscircuit/tscircuit.com",
       "tscircuit/tscircuit",
       "tscircuit/cli",
@@ -17,7 +24,7 @@ export async function getRepos(): Promise<string[]> {
       "tscircuit/soup",
       "tscircuit/props",
       "tscircuit/jscad-fiber",
-    ]
+    ])
   }
 
   let repos: string[] = []
@@ -40,5 +47,5 @@ export async function getRepos(): Promise<string[]> {
 
   // Process complete
 
-  return repos
+  return excludeNonPointAwardingRepos(repos)
 }

--- a/tests/test-repo-exclusions.test.ts
+++ b/tests/test-repo-exclusions.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import { excludeNonPointAwardingRepos } from "lib/data-retrieval/getRepos"
+
+test("sparkfun-boards does not award contribution points", () => {
+  expect(
+    excludeNonPointAwardingRepos([
+      "tscircuit/tscircuit",
+      "tscircuit/sparkfun-boards",
+    ]),
+  ).toEqual(["tscircuit/tscircuit"])
+})


### PR DESCRIPTION
## Summary
- exclude `tscircuit/sparkfun-boards` from repositories processed for contribution points
- apply the exclusion to both organization-wide and `SHORT_REPO_LIST` runs
- remove the repository-specific three-star board bonus
- add a regression test for the exclusion

## Verification
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`