### PR TITLE
Exclude downvoted review credit and apply penalties per week

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { mergeReviewWeeks } from "lib/scoring/review-weeks"
 import * as fs from "fs"
 import { analyzePRWithAI } from "lib/ai-stuff/analyze-pr"
 import { getContributionOverviewWindow } from "lib/ai/date-utils"
@@ -145,6 +146,13 @@ export async function generateOverview(
                 login: reviewerLogin,
               },
             )
+            reviewerContributorStats.reviewWeeks = mergeReviewWeeks(
+              reviewerContributorStats.reviewWeeks,
+              reviewerStats.reviewWeeks,
+            )
+            reviewerContributorStats.downvotedReviews =
+              (reviewerContributorStats.downvotedReviews ?? 0) +
+              (reviewerStats.downvotedReviews ?? 0)
             reviewerContributorStats.approvalsGiven +=
               reviewerStats.approvalsGiven
             reviewerContributorStats.rejectionsGiven +=

--- a/lib/contributor-identity.ts
+++ b/lib/contributor-identity.ts
@@ -1,3 +1,4 @@
+import { mergeReviewWeeks } from "./scoring/review-weeks"
 import { scoreToStarString } from "./scoring/scoreToStars"
 import type { AnalyzedPR, ContributorStats } from "./types"
 
@@ -43,6 +44,7 @@ const ADDITIVE_CONTRIBUTOR_STAT_FIELDS = [
   "bountiedIssuesCount",
   "bountiedIssuesTotal",
   "score",
+  "downvotedReviews",
   "approvalsGiven",
   "rejectionsGiven",
   "distinctPrsReviewedNonCodeOwner",
@@ -96,6 +98,7 @@ export function createEmptyContributorStats(
     staffRejectionsReceived: 0,
     staffApprovalsReceived: 0,
     staffReviewedPrLinks: [],
+    downvotedReviews: 0,
     approvalsGiven: 0,
     rejectionsGiven: 0,
     prsOpened: 0,
@@ -153,6 +156,13 @@ export function mergeContributorStats(
           (typeof secondStat === "number" ? secondStat : 0),
       })
     }
+  }
+
+  if (firstContributorStats.reviewWeeks || secondContributorStats.reviewWeeks) {
+    mergedContributorStats.reviewWeeks = mergeReviewWeeks(
+      firstContributorStats.reviewWeeks,
+      secondContributorStats.reviewWeeks,
+    )
   }
 
   mergedContributorStats.githubId =

--- a/lib/data-processing/generateMarkdown.ts
+++ b/lib/data-processing/generateMarkdown.ts
@@ -198,6 +198,8 @@ export async function generateMarkdown(
   markdown += "## Review Table\n\n"
 
   const columnTitleToDescription = {
+    "Downvoted Reviews":
+      "Reviews submitted in the reporting period with a thumbs-down reaction",
     "Reviews Received":
       "Number of reviews received for PRs for this contributor",
     "Approvals Received":
@@ -226,6 +228,7 @@ export async function generateMarkdown(
     "Reviews Received": "reviewsReceived",
     "Approvals Received": "approvalsReceived",
     "Rejections Received": "rejectionsReceived",
+    "Downvoted Reviews": "downvotedReviews",
     Approvals: "approvalsGiven",
     "Rejections Given": "rejectionsGiven",
     "PRs Opened": "prsOpened",
@@ -255,7 +258,7 @@ export async function generateMarkdown(
           markdown += ` [${contributor}](#${contributor.replace(/\s/g, "-")}) |`
           return
         }
-        markdown += ` ${stats[columnTitleToPropName[columnTitle] as keyof ContributorStats]} |`
+        markdown += ` ${stats[columnTitleToPropName[columnTitle] as keyof ContributorStats] ?? 0} |`
       })
       markdown += "\n"
     },

--- a/lib/data-retrieval/cachedOctokit.ts
+++ b/lib/data-retrieval/cachedOctokit.ts
@@ -1,3 +1,7 @@
+import {
+  REVIEW_DOWNVOTES_QUERY,
+  type ReviewReactionNode,
+} from "./getReviewDownvotes"
 import { Octokit } from "@octokit/rest"
 import FileSystemCache from "file-system-cache"
 import type { Endpoints } from "@octokit/types"
@@ -124,6 +128,22 @@ export class CachedOctokit {
       )
       return response
     },
+  }
+
+  public reviewReactionNodes = async (
+    ids: string[],
+  ): Promise<(ReviewReactionNode | null)[]> => {
+    const params = { ids }
+    const cached = await this.getCached<(ReviewReactionNode | null)[]>(
+      "reviews.downvotes",
+      params,
+    )
+    if (cached) return cached
+    const result = await this.octokit.graphql<{
+      nodes: (ReviewReactionNode | null)[]
+    }>(REVIEW_DOWNVOTES_QUERY, params)
+    await this.setCached("reviews.downvotes", params, result.nodes)
+    return result.nodes
   }
 
   public issues = {

--- a/lib/data-retrieval/getAllPRs.ts
+++ b/lib/data-retrieval/getAllPRs.ts
@@ -1,3 +1,5 @@
+import { getReviewWeek } from "../scoring/review-weeks"
+import { getReviewDownvotes } from "./getReviewDownvotes"
 import { octokit } from "lib/sdks"
 import { resolveContributorIdentity } from "../contributor-identity"
 import type { PullRequestWithReviews, ReviewerStats } from "../types"
@@ -7,10 +9,11 @@ export async function getAllPRs(
   repo: string,
   since: string,
   currentTime: Date = new Date(),
+  client: Pick<typeof octokit, "pulls" | "reviewReactionNodes"> = octokit,
 ): Promise<PullRequestWithReviews[]> {
   const [owner, repo_name] = repo.split("/")
   const fetchPRs = async (page = 1): Promise<any[]> => {
-    const { data } = await octokit.pulls.list({
+    const { data } = await client.pulls.list({
       owner,
       repo: repo_name,
       sort: "updated",
@@ -46,7 +49,7 @@ export async function getAllPRs(
   })
 
   const fetchReviews = async (prNumber: number, page = 1): Promise<any[]> => {
-    const { data } = await octokit.pulls.listReviews({
+    const { data } = await client.pulls.listReviews({
       owner,
       repo: repo_name,
       pull_number: prNumber,
@@ -65,6 +68,10 @@ export async function getAllPRs(
     filteredPRs,
     async (pr) => {
       const reviews = await fetchReviews(pr.number)
+      const downvotedReviewIds = await getReviewDownvotes(
+        reviews.map((review) => review.node_id),
+        (ids) => client.reviewReactionNodes(ids),
+      )
       const isMerged = !!pr.merged_at
 
       const allReviewsByUser = reviews.reduce<Record<string, ReviewerStats>>(
@@ -145,6 +152,9 @@ export async function getAllPRs(
           }
         }
 
+        // Keep the raw review counts above; only withhold scoring credit.
+        if (downvotedReviewIds.has(review.node_id)) return acc
+
         if (isMerged) {
           // For merged PRs, only add to prNumbers if approved
           if (review.state === "APPROVED") {
@@ -164,6 +174,39 @@ export async function getAllPRs(
         }
         return acc
       }, {})
+
+      // Persist weekly evidence so longer reports do not apply a month-wide penalty.
+      for (const stats of Object.values(reviewsByUser)) stats.reviewWeeks = {}
+      for (const review of reviews) {
+        if (!review.user) continue
+        const submittedAt = Date.parse(review.submitted_at)
+        if (!Number.isFinite(submittedAt)) continue
+        const key = resolveContributorIdentity(
+          review.user,
+        ).contributorIdentityKey
+        const stats = reviewsByUser[key]
+        if (!stats) continue
+        const week = getReviewWeek(review.submitted_at)
+        const weekly = (stats.reviewWeeks![week] ??= {
+          downvotedReviewIds: [],
+          eligiblePrs: [],
+        })
+        if (downvotedReviewIds.has(review.node_id)) {
+          weekly.downvotedReviewIds.push(review.node_id)
+          if (
+            submittedAt >= sinceDate.getTime() &&
+            submittedAt <= currentTimeMs
+          ) {
+            stats.downvotedReviews = (stats.downvotedReviews ?? 0) + 1
+          }
+        } else if (
+          isMerged &&
+          review.state === "APPROVED" &&
+          processedReviews.includes(review)
+        ) {
+          weekly.eligiblePrs.push(`${repo}#${pr.number}`)
+        }
+      }
 
       return {
         ...pr,

--- a/lib/data-retrieval/getReviewDownvotes.ts
+++ b/lib/data-retrieval/getReviewDownvotes.ts
@@ -1,0 +1,39 @@
+export interface ReviewReactionNode {
+  id: string
+  reactions: { totalCount: number }
+}
+
+export const REVIEW_DOWNVOTES_QUERY = `
+  query ReviewDownvotes($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      ... on PullRequestReview {
+        id
+        reactions(content: THUMBS_DOWN) { totalCount }
+      }
+    }
+  }
+`
+
+/** REST reviews omit body reactions. Fetch the same review nodes via GraphQL. */
+export async function getReviewDownvotes(
+  ids: string[],
+  fetchNodes: (ids: string[]) => Promise<(ReviewReactionNode | null)[]>,
+): Promise<Set<string>> {
+  const downvoted = new Set<string>()
+  const uniqueIds = [...new Set(ids)]
+  for (let offset = 0; offset < uniqueIds.length; offset += 100) {
+    const batch = uniqueIds.slice(offset, offset + 100)
+    const nodes = await fetchNodes(batch)
+    const byId = new Map(
+      nodes.filter((node) => node !== null).map((node) => [node.id, node]),
+    )
+    for (const id of batch) {
+      const count = byId.get(id)?.reactions?.totalCount
+      if (count === undefined || !Number.isInteger(count) || count < 0) {
+        throw new Error(`Missing review reaction data for ${id}`)
+      }
+      if (count > 0) downvoted.add(id)
+    }
+  }
+  return downvoted
+}

--- a/lib/scoring/getContributorScore.ts
+++ b/lib/scoring/getContributorScore.ts
@@ -1,3 +1,4 @@
+import { countEligibleReviewedPrs } from "./review-weeks"
 import { MAINTAINERS } from "./maintainers"
 import type { AnalyzedPR, ContributorStats } from "../types"
 
@@ -93,13 +94,21 @@ export function getContributorScore({
   const isMaintainer =
     contributor && (MAINTAINERS as Record<string, string>)[contributor]
 
-  const totalDistinctPrsReviewed =
-    (contributorStats.distinctPrsReviewedNonCodeOwner || 0) +
-    (contributorStats.distinctPrsReviewedAsCodeOwner || 0)
+  const totalDistinctPrsReviewed = contributorStats.reviewWeeks
+    ? countEligibleReviewedPrs(contributorStats.reviewWeeks)
+    : (contributorStats.distinctPrsReviewedNonCodeOwner || 0) +
+      (contributorStats.distinctPrsReviewedAsCodeOwner || 0)
   let reviewPoints = Math.min(totalDistinctPrsReviewed, isMaintainer ? 15 : 5)
 
   if (!isMaintainer) {
     reviewPoints = Math.min(reviewPoints, impactWorth.Tiny)
+  }
+
+  if (
+    !contributorStats.reviewWeeks &&
+    (contributorStats.downvotedReviews ?? 0) >= 3
+  ) {
+    reviewPoints = 0
   }
 
   result.score += reviewPoints

--- a/lib/scoring/review-weeks.ts
+++ b/lib/scoring/review-weeks.ts
@@ -1,0 +1,49 @@
+import { CONTRIBUTION_OVERVIEW_CUTOFF_HOUR_UTC } from "../ai/date-utils"
+
+export interface ReviewWeekStats {
+  downvotedReviewIds: string[]
+  eligiblePrs: string[]
+}
+export type ReviewWeeks = Record<string, ReviewWeekStats>
+
+/** Tuesday 18:00 UTC starts a reporting week. */
+export function getReviewWeek(submittedAt: string): string {
+  const date = new Date(submittedAt)
+  const start = new Date(date)
+  start.setUTCHours(CONTRIBUTION_OVERVIEW_CUTOFF_HOUR_UTC, 0, 0, 0)
+  start.setUTCDate(start.getUTCDate() - ((start.getUTCDay() + 5) % 7))
+  if (start > date) start.setUTCDate(start.getUTCDate() - 7)
+  return start.toISOString()
+}
+
+export function mergeReviewWeeks(
+  first: ReviewWeeks = {},
+  second: ReviewWeeks = {},
+): ReviewWeeks {
+  const result: ReviewWeeks = {}
+  for (const week of new Set([...Object.keys(first), ...Object.keys(second)])) {
+    result[week] = {
+      downvotedReviewIds: [
+        ...new Set([
+          ...(first[week]?.downvotedReviewIds ?? []),
+          ...(second[week]?.downvotedReviewIds ?? []),
+        ]),
+      ],
+      eligiblePrs: [
+        ...new Set([
+          ...(first[week]?.eligiblePrs ?? []),
+          ...(second[week]?.eligiblePrs ?? []),
+        ]),
+      ],
+    }
+  }
+  return result
+}
+
+export function countEligibleReviewedPrs(weeks: ReviewWeeks): number {
+  return new Set(
+    Object.values(weeks).flatMap((week) =>
+      new Set(week.downvotedReviewIds).size >= 3 ? [] : week.eligiblePrs,
+    ),
+  ).size
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,4 @@
+import type { ReviewWeeks } from "./scoring/review-weeks"
 import type { z } from "zod"
 import type {
   pr_attribute_schema,
@@ -7,6 +8,8 @@ import type {
 export interface ReviewerStats {
   githubId?: number
   githubLogin: string
+  reviewWeeks?: ReviewWeeks
+  downvotedReviews?: number
   approvalsGiven: number
   rejectionsGiven: number
   prNumbers?: Set<number> // Set of PR numbers this reviewer has reviewed
@@ -36,6 +39,8 @@ export interface ContributorStats {
   bountiedIssuesCount?: number
   bountiedIssuesTotal?: number
   score?: number
+  reviewWeeks?: ReviewWeeks
+  downvotedReviews?: number
   approvalsGiven: number
   rejectionsGiven: number
   distinctPrsReviewedNonCodeOwner?: number // Number of unique PRs reviewed by this contributor

--- a/tests/__snapshots__/test-generate-markdown.test.ts.snap
+++ b/tests/__snapshots__/test-generate-markdown.test.ts.snap
@@ -50,16 +50,17 @@ pie
 
 ## Review Table
 
+[downvoted-reviews-hover]: ## "Reviews submitted in the reporting period with a thumbs-down reaction"
 [reviews-received-hover]: ## "Number of reviews received for PRs for this contributor"
 [approvals-received-hover]: ## "Number of approvals received for PRs this contributor authored"
 [rejections-received-hover]: ## "Number of rejections received for PRs this contributor authored"
 [prs-opened-hover]: ## "Number of PRs opened by this contributor"
 [issues-created-hover]: ## "Number of issues created by this contributor"
 
-| Contributor | Reviews Received | Approvals Received | Rejections Received | Approvals | Rejections Given | PRs Opened | PRs Merged | Issues Created |
-|---|---|---|---|---|---|---|---|---|
-| [alice](#alice) | 1 | 1 | 0 | 2 | 0 | 2 | 1 | 1 |
-| [bob](#bob) | 0 | 0 | 0 | 1 | 0 | 1 | 0 | 0 |
+| Contributor | Reviews Received | Approvals Received | Rejections Received | Downvoted Reviews | Approvals | Rejections Given | PRs Opened | PRs Merged | Issues Created |
+|---|---|---|---|---|---|---|---|---|---|
+| [alice](#alice) | 1 | 1 | 0 | 2 | 2 | 0 | 2 | 1 | 1 |
+| [bob](#bob) | 0 | 0 | 0 | 0 | 1 | 0 | 1 | 0 | 0 |
 
 ## Changes by Repository
 

--- a/tests/test-downvoted-reviews.test.ts
+++ b/tests/test-downvoted-reviews.test.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "bun:test"
+import { getReviewDownvotes } from "../lib/data-retrieval/getReviewDownvotes"
+import { getAllPRs } from "../lib/data-retrieval/getAllPRs"
+import {
+  createEmptyContributorStats,
+  mergeContributorStats,
+} from "../lib/contributor-identity"
+import { getContributorScore } from "../lib/scoring/getContributorScore"
+import { MAINTAINERS } from "../lib/scoring/maintainers"
+import type { AnalyzedPR } from "../lib/types"
+
+test("fetches more than 100 review nodes and counts reviews, not reactions", async () => {
+  const ids = Array.from({ length: 101 }, (_, i) => `review-${i}`)
+  const sizes: number[] = []
+  const result = await getReviewDownvotes([...ids, ids[0]], async (batch) => {
+    sizes.push(batch.length)
+    return batch.map((id) => ({
+      id,
+      reactions: { totalCount: id === ids[100] ? 7 : 0 },
+    }))
+  })
+  expect(sizes).toEqual([100, 1])
+  expect([...result]).toEqual([ids[100]])
+})
+
+test("missing reaction data fails instead of awarding credit", async () => {
+  await expect(
+    getReviewDownvotes(["deleted"], async () => [null]),
+  ).rejects.toThrow("Missing review reaction data")
+  await expect(
+    getReviewDownvotes(["r"], async () => {
+      throw new Error("API unavailable")
+    }),
+  ).rejects.toThrow("API unavailable")
+  expect(
+    await getReviewDownvotes([], async () => {
+      throw new Error("not called")
+    }),
+  ).toEqual(new Set())
+})
+
+test("downvotes withhold credit without changing received counts or reviving an earlier approval", async () => {
+  const reviews = [
+    {
+      node_id: "old",
+      user: { id: 1, login: "old-name" },
+      state: "APPROVED",
+      submitted_at: "2026-09-01T00:00:00Z",
+    },
+    {
+      node_id: "bad",
+      user: { id: 1, login: "new-name" },
+      state: "APPROVED",
+      submitted_at: "2026-09-04T00:00:00Z",
+    },
+    {
+      node_id: "bad2",
+      user: { id: 1, login: "new-name" },
+      state: "COMMENTED",
+      submitted_at: "2026-09-05T00:00:00Z",
+    },
+    {
+      node_id: "good",
+      user: { id: 2, login: "other" },
+      state: "APPROVED",
+      submitted_at: "2026-09-05T00:00:00Z",
+    },
+  ]
+  const client = {
+    pulls: {
+      list: async () => ({
+        data: [
+          {
+            number: 1,
+            user: { login: "author" },
+            created_at: "2026-09-03T00:00:00Z",
+            merged_at: "2026-09-06T00:00:00Z",
+            state: "closed",
+          },
+        ],
+      }),
+      listReviews: async () => ({ data: reviews }),
+    },
+    reviewReactionNodes: async (ids: string[]) =>
+      ids.map((id) => ({
+        id,
+        reactions: { totalCount: id === "good" ? 0 : 2 },
+      })),
+  } as unknown as NonNullable<Parameters<typeof getAllPRs>[3]>
+  const [pr] = await getAllPRs(
+    "org/repo",
+    "2026-09-03",
+    new Date("2026-09-07"),
+    client,
+  )
+  expect(pr.reviewsReceived).toBe(2)
+  expect(pr.approvalsReceived).toBe(1)
+  expect(pr.allReviewsByUser?.["github:1"].approvalsGiven).toBe(2)
+  expect(pr.reviewsByUser?.["github:1"].prNumbers?.size).toBe(0)
+  expect(pr.reviewsByUser?.["github:1"].downvotedReviews).toBe(2)
+  expect(pr.reviewsByUser?.["github:2"].prNumbers?.has(1)).toBe(true)
+})
+
+test("three downvoted reviews remove only review points for maintainers and contributors", () => {
+  for (const contributor of [
+    "ordinary-contributor",
+    Object.keys(MAINTAINERS)[0],
+  ]) {
+    const stats = {
+      ...createEmptyContributorStats(),
+      distinctPrsReviewedNonCodeOwner: 10,
+      downvotedReviews: 2,
+    }
+    const contributorPRs = [{ starRating: 3, impact: "Major" }] as AnalyzedPR[]
+    const before = getContributorScore({
+      contributor,
+      contributorPRs,
+      contributorStats: stats,
+    })
+    expect(before.score).toBeGreaterThan(4)
+    for (const downvotedReviews of [3, 4]) {
+      const after = getContributorScore({
+        contributor,
+        contributorPRs,
+        contributorStats: { ...stats, downvotedReviews },
+      })
+      expect(after.score).toBe(4)
+      expect(after.rating3Count).toBe(before.rating3Count)
+    }
+    expect(
+      mergeContributorStats(stats, {
+        ...createEmptyContributorStats(),
+        downvotedReviews: 1,
+      }).downvotedReviews,
+    ).toBe(3)
+  }
+})
+
+import {
+  getReviewWeek,
+  mergeReviewWeeks,
+  countEligibleReviewedPrs,
+  type ReviewWeeks,
+} from "../lib/scoring/review-weeks"
+
+test("weekly attribution changes at Tuesday 18:00 UTC", () => {
+  expect(getReviewWeek("2026-09-08T17:59:59.999Z")).toBe(
+    "2026-09-01T18:00:00.000Z",
+  )
+  expect(getReviewWeek("2026-09-08T18:00:00.000Z")).toBe(
+    "2026-09-08T18:00:00.000Z",
+  )
+  expect(getReviewWeek("2026-09-09T12:00:00Z")).toBe("2026-09-08T18:00:00.000Z")
+})
+
+test("three downvoted reviews spread across three weeks do not penalize the month", () => {
+  const weeks: ReviewWeeks = {}
+  for (const [i, day] of ["02", "09", "16"].entries()) {
+    weeks[getReviewWeek(`2026-09-${day}T12:00:00Z`)] = {
+      downvotedReviewIds: [`review-${i}`],
+      eligiblePrs: [`org/repo#${i}`],
+    }
+  }
+  const contributor = Object.keys(MAINTAINERS)[0]
+  const contributorPRs = [{ starRating: 3, impact: "Major" }] as AnalyzedPR[]
+  const stats = {
+    ...createEmptyContributorStats(),
+    downvotedReviews: 3,
+    reviewWeeks: weeks,
+  }
+  expect(
+    getContributorScore({
+      contributor,
+      contributorPRs,
+      contributorStats: stats,
+    }).score,
+  ).toBe(7)
+  const badWeek = Object.keys(weeks)[0]
+  const penalized = mergeReviewWeeks(weeks, {
+    [badWeek]: {
+      downvotedReviewIds: ["review-extra1", "review-extra2"],
+      eligiblePrs: [],
+    },
+  })
+  expect(
+    getContributorScore({
+      contributor,
+      contributorPRs,
+      contributorStats: { ...stats, reviewWeeks: penalized },
+    }).score,
+  ).toBe(6)
+  expect(
+    getContributorScore({
+      contributor: "ordinary",
+      contributorPRs,
+      contributorStats: stats,
+    }).score,
+  ).toBe(5)
+  expect(countEligibleReviewedPrs(mergeReviewWeeks(weeks, weeks))).toBe(3)
+  expect(
+    mergeReviewWeeks(weeks, weeks)[badWeek].downvotedReviewIds,
+  ).toHaveLength(1)
+  const cappedWeeks = {
+    [badWeek]: {
+      downvotedReviewIds: [],
+      eligiblePrs: Array.from({ length: 20 }, (_, i) => `org/repo#${i}`),
+    },
+  }
+  expect(
+    getContributorScore({
+      contributor,
+      contributorPRs,
+      contributorStats: { ...stats, reviewWeeks: cappedWeeks },
+    }).score,
+  ).toBe(19)
+})

--- a/tests/test-generate-markdown.test.ts
+++ b/tests/test-generate-markdown.test.ts
@@ -113,6 +113,7 @@ const mockStats: Record<string, ContributorStats> = {
         staffRejections: 0,
       },
     ],
+    downvotedReviews: 2,
     approvalsGiven: 2,
     rejectionsGiven: 0,
     prsOpened: 2,


### PR DESCRIPTION
Reviews with thumbs-down reactions currently contribute review points. This change fetches reaction counts on review bodies through GraphQL, excludes affected reviews from credit, and shows downvoted review counts in the review table. Three distinct downvoted reviews remove review credit for that Tuesday-18:00-UTC week; monthly reports preserve eligible credit from other weeks. PR points and existing review caps remain unchanged.

Validation: 63 local tests pass (149 assertions), including missing API data, pagination, identity merging, weekly cutoff and monthly attribution. TypeScript check passes. All 12 uploaded files were read back and matched the tested local contents.

GitHub Actions test, type-check and format-check jobs pass at the submitted commit. The GraphQL call is schema-backed and tested with fixtures but has not been exercised against an authenticated live API here. This retains the existing selected-PR universe and latest-review eligibility policy. It reads current reactions with the existing six-hour cache pattern; it does not reconstruct past reaction state. Related #334 changes review eligibility policy and would need reconciliation if merged first.

Implemented and reviewed with OpenAI Codex agents under my authorization; no claim of independent human code review.

Relates to #264.