### PR TITLE
fix(notifications): split Discord issue batches over 2,000 characters

### DIFF
--- a/lib/utils/split-discord-content.ts
+++ b/lib/utils/split-discord-content.ts
@@ -1,0 +1,112 @@
+/**
+ * Discord rejects webhook payloads whose `content` exceeds 2,000 characters.
+ * Notifications that list every new issue can easily pass that limit, so the
+ * content has to be split before it is sent.
+ *
+ * @see https://discord.com/developers/docs/resources/webhook
+ */
+export const DISCORD_MAX_CONTENT_LENGTH = 2000
+
+const isHighSurrogate = (code: number) => code >= 0xd800 && code <= 0xdbff
+const isLowSurrogate = (code: number) => code >= 0xdc00 && code <= 0xdfff
+
+/**
+ * Move `index` back by one when it would split a UTF-16 surrogate pair, so no
+ * chunk ever ends with half of a character.
+ */
+const avoidSplittingSurrogatePair = (text: string, index: number): number => {
+  if (index <= 0 || index >= text.length) return index
+  if (
+    isHighSurrogate(text.charCodeAt(index - 1)) &&
+    isLowSurrogate(text.charCodeAt(index))
+  ) {
+    return index - 1
+  }
+  return index
+}
+
+/**
+ * Split `content` into chunks of at most `limit` characters.
+ *
+ * Lines are kept whole whenever they fit, which keeps issue entries readable.
+ * A single line that cannot fit is split on a character boundary that never
+ * breaks a surrogate pair. Joining the chunks with "\n" reproduces the input,
+ * so no notification is silently dropped.
+ */
+export const splitDiscordContent = (
+  content: string,
+  limit: number = DISCORD_MAX_CONTENT_LENGTH,
+): string[] => {
+  if (content.length === 0) return []
+
+  const max = Math.max(1, Math.floor(limit))
+  if (content.length <= max) return [content]
+
+  const chunks: string[] = []
+  let current = ""
+
+  const flush = () => {
+    if (current.length > 0) {
+      chunks.push(current)
+      current = ""
+    }
+  }
+
+  for (const line of content.split("\n")) {
+    if (line.length === 0) {
+      // Preserve blank lines: an empty line still needs its separator.
+      if (current.length === 0) {
+        chunks.push("")
+      } else if (current.length + 1 <= max) {
+        current += "\n"
+      } else {
+        flush()
+        chunks.push("")
+      }
+      continue
+    }
+
+    if (current.length === 0) {
+      if (line.length <= max) {
+        current = line
+        continue
+      }
+      chunks.push(...splitLongLine(line, max))
+      continue
+    }
+
+    if (current.length + 1 + line.length <= max) {
+      current += `\n${line}`
+      continue
+    }
+
+    flush()
+    if (line.length <= max) {
+      current = line
+    } else {
+      chunks.push(...splitLongLine(line, max))
+    }
+  }
+
+  flush()
+  return chunks.length > 0 ? chunks : [""]
+}
+
+const splitLongLine = (line: string, max: number): string[] => {
+  const parts: string[] = []
+  let start = 0
+
+  while (start < line.length) {
+    let end = Math.min(start + max, line.length)
+    end = avoidSplittingSurrogatePair(line, end)
+    if (end <= start) {
+      // Never stall: a single code point that cannot fit on its own still has
+      // to advance, otherwise this loop would never terminate.
+      end = start + 1
+    }
+    parts.push(line.slice(start, end))
+    start = end
+  }
+
+  return parts
+}

--- a/scripts/issue-notifications.ts
+++ b/scripts/issue-notifications.ts
@@ -2,6 +2,7 @@ import { WebhookClient, type MessageCreateOptions } from "discord.js"
 import { getRepos } from "lib/data-retrieval/getRepos"
 import { octokit } from "lib/sdks"
 import { EXCLUDED_BOTS } from "lib/constants"
+import { splitDiscordContent } from "lib/utils/split-discord-content"
 
 const discordWebhook = new WebhookClient({
   url: process.env.ISSUES_DISCORD_WEBHOOK_URL || "",
@@ -70,15 +71,21 @@ async function notifyDiscord(issues: Issue[], repo: string) {
       )
       .join("\n")
 
-  const messageOptions: MessageCreateOptions = {
-    content: messageContent,
-    allowedMentions: { parse: [] }, // This prevents link previews
-  }
+  // Discord rejects any payload over 2,000 characters, so a busy repository
+  // has to be announced in several messages instead of one oversized one.
+  const chunks = splitDiscordContent(messageContent)
 
-  await discordWebhook.send(messageOptions)
-  console.log(
-    `[${getUTCDateTime()}] Successfully sent Discord notification for ${repo}`,
-  )
+  for (const [index, content] of chunks.entries()) {
+    const messageOptions: MessageCreateOptions = {
+      content,
+      allowedMentions: { parse: [] }, // This prevents link previews
+    }
+
+    await discordWebhook.send(messageOptions)
+    console.log(
+      `[${getUTCDateTime()}] Sent Discord notification chunk ${index + 1}/${chunks.length} for ${repo}`,
+    )
+  }
 }
 
 async function main() {

--- a/tests/test-discord-content-splitting.test.ts
+++ b/tests/test-discord-content-splitting.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "bun:test"
+import {
+  DISCORD_MAX_CONTENT_LENGTH,
+  splitDiscordContent,
+} from "../lib/utils/split-discord-content"
+
+const buildIssueList = (count: number): string => {
+  const title = "A realistic notification title ".repeat(3)
+  const lines = Array.from(
+    { length: count },
+    (_, i) =>
+      `• #${i + 1} ${title}by contributor - <https://github.com/example/repo/issues/${i + 1}>`,
+  )
+  return `New issues in tscircuit/example:\n${lines.join("\n")}`
+}
+
+test("empty content yields no chunks", () => {
+  expect(splitDiscordContent("")).toEqual([])
+})
+
+test("content below the limit is returned unchanged", () => {
+  const content = "New issues in tscircuit/example:\n• #1 hello"
+  expect(splitDiscordContent(content)).toEqual([content])
+})
+
+test("content of exactly the limit stays a single chunk", () => {
+  const content = "a".repeat(DISCORD_MAX_CONTENT_LENGTH)
+  const chunks = splitDiscordContent(content)
+  expect(chunks).toHaveLength(1)
+  expect(chunks[0].length).toBe(DISCORD_MAX_CONTENT_LENGTH)
+})
+
+test("one character over the limit is split in two", () => {
+  const content = `${"a".repeat(DISCORD_MAX_CONTENT_LENGTH - 1)}\nb`
+  const chunks = splitDiscordContent(content)
+  expect(chunks.length).toBeGreaterThan(1)
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeLessThanOrEqual(DISCORD_MAX_CONTENT_LENGTH)
+  }
+  expect(chunks.join("\n")).toBe(content)
+})
+
+test("a batch of 30 issues keeps every entry and respects the limit", () => {
+  const content = buildIssueList(30)
+  expect(content.length).toBeGreaterThan(DISCORD_MAX_CONTENT_LENGTH)
+
+  const chunks = splitDiscordContent(content)
+  expect(chunks.length).toBeGreaterThan(1)
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeLessThanOrEqual(DISCORD_MAX_CONTENT_LENGTH)
+  }
+  // Joining on the line separator reproduces the payload, so nothing is lost.
+  expect(chunks.join("\n")).toBe(content)
+  for (let i = 1; i <= 30; i++) {
+    expect(chunks.join("\n")).toContain(`• #${i} `)
+  }
+})
+
+test("a surrogate pair at the boundary is not broken", () => {
+  const limit = 4
+  // "😀" is a surrogate pair; a naive 4-code-unit slice would split it.
+  const content = "a😀b"
+  const chunks = splitDiscordContent(content, limit)
+  expect(chunks.join("")).toBe(content)
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeLessThanOrEqual(limit)
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/.test(
+        chunk,
+      ),
+    ).toBe(false)
+  }
+})
+
+test("a single line longer than the limit is split without losing characters", () => {
+  const line = "x".repeat(DISCORD_MAX_CONTENT_LENGTH * 2 + 5)
+  const chunks = splitDiscordContent(line)
+  expect(chunks.length).toBeGreaterThan(2)
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeLessThanOrEqual(DISCORD_MAX_CONTENT_LENGTH)
+  }
+  expect(chunks.join("")).toBe(line)
+})
+
+test("multiline content keeps its line structure", () => {
+  const content = `first line\n${"y".repeat(DISCORD_MAX_CONTENT_LENGTH)}\nlast line`
+  const chunks = splitDiscordContent(content)
+  for (const chunk of chunks) {
+    expect(chunk.length).toBeLessThanOrEqual(DISCORD_MAX_CONTENT_LENGTH)
+  }
+  expect(chunks.join("\n")).toBe(content)
+})


### PR DESCRIPTION
Closes #359

## Problem

`notifyDiscord()` joins every new issue for a repository into a single `content` string and sends it with no length check. Discord rejects webhook payloads over [2,000 characters](https://discord.com/developers/docs/resources/webhook), and a batch of ~30 issues with ordinary-length titles already exceeds that. A rejected send also escapes the sequential repository loop in `main()`, so later repositories are not notified in that run.

## Fix

- New helper `lib/utils/splitDiscordContent.ts`: splits content into chunks of at most 2,000 characters.
  - Lines are kept whole whenever they fit, so issue entries stay readable.
  - A single line that cannot fit is split on a boundary that never breaks a UTF-16 surrogate pair.
  - Joining the chunks with `\n` reproduces the input, so no notification is silently dropped.
- `notifyDiscord()` now sends the chunks sequentially, preserving `allowedMentions: { parse: [] }` (no link previews) and the existing failure semantics — a transport failure still propagates, with no automatic retry.

Scope is deliberately narrow: `main()`'s error handling is unchanged.

## Validation

- New `tests/test-discord-content-splitting.test.ts` — 8 cases: empty content, below limit, exactly at the limit, one over, the 30-issue batch from the issue (every entry preserved, every chunk within the limit), a surrogate pair at the boundary, a single over-long line, and multiline content.
- Full suite: **65 passed / 0 failed** (bun 1.4.2).
- `tsc --noEmit` clean, `biome format` clean on the touched files.

> **Disclosure:** this PR was prepared with AI assistance (implementation and tests), reviewed and validated locally.